### PR TITLE
Fix maintenance search refresh and clear frontend warnings

### DIFF
--- a/frontend/src/app/dashboard/leases/page.tsx
+++ b/frontend/src/app/dashboard/leases/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import api, {
   LeaseAgreementWithTenant,
   LeaseStatusSummary,
@@ -35,11 +35,7 @@ export default function LeasesPage() {
   const [uploadSigned, setUploadSigned] = useState<LeaseAgreementWithTenant | null>(null);
   const [deleteLease, setDeleteLease] = useState<LeaseAgreementWithTenant | null>(null);
 
-  useEffect(() => {
-    loadData();
-  }, [filterProperty, filterStatus]);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       const [leasesRes, summaryRes, propertiesRes, tenantsRes] = await Promise.all([
         api.getLeases({
@@ -59,7 +55,11 @@ export default function LeasesPage() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [filterProperty, filterStatus]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
 
   const filteredLeases = leases.filter(
     (lease) =>

--- a/frontend/src/app/dashboard/maintenance/page.tsx
+++ b/frontend/src/app/dashboard/maintenance/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import api, {
   MaintenanceRequest,
   MaintenanceStatusValue,
@@ -54,7 +54,7 @@ export default function MaintenancePage() {
   const [commentInternal, setCommentInternal] = useState(false);
   const [commentFile, setCommentFile] = useState<File | null>(null);
 
-  const loadRequests = async () => {
+  const loadRequests = useCallback(async () => {
     try {
       setError("");
       const res = await api.getMaintenanceRequests({
@@ -68,11 +68,11 @@ export default function MaintenancePage() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [statusFilter, urgencyFilter, search]);
 
   useEffect(() => {
     void loadRequests();
-  }, [statusFilter, urgencyFilter]);
+  }, [loadRequests]);
 
   const refreshDetail = async (requestId: string) => {
     const item = await api.getMaintenanceRequest(requestId);

--- a/frontend/src/app/dashboard/notifications/page.tsx
+++ b/frontend/src/app/dashboard/notifications/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Bell, Filter, Check, CheckCheck, Search, X, Loader2, Download } from "lucide-react";
+import { Bell, Check, CheckCheck, Search, X, Loader2 } from "lucide-react";
 import api, { NotificationItem } from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
 

--- a/frontend/src/app/dashboard/payments/page.tsx
+++ b/frontend/src/app/dashboard/payments/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import api, {
   PaymentWithTenant,
   PaymentSummary,
@@ -47,11 +47,7 @@ export default function PaymentsPage() {
   const [disputePayment, setDisputePayment] = useState<PaymentWithTenant | null>(null);
   const [exportModalOpen, setExportModalOpen] = useState(false);
 
-  useEffect(() => {
-    loadData();
-  }, [filterProperty, filterStatus, dateRange]);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       const [paymentsRes, summaryRes, propertiesRes] = await Promise.all([
         api.getPayments({
@@ -71,7 +67,11 @@ export default function PaymentsPage() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [dateRange, filterProperty, filterStatus]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
 
   const filteredPayments = payments.filter(
     (payment) =>

--- a/frontend/src/app/dashboard/properties/[id]/page.tsx
+++ b/frontend/src/app/dashboard/properties/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
 import Link from "next/link";
 import api, { PropertyWithStats, RoomWithTenant } from "@/lib/api";
 import { useToast } from "@/components/toast-provider";
@@ -37,7 +37,6 @@ const CURRENCIES = [
 
 export default function PropertyDetailPage() {
   const params = useParams();
-  const router = useRouter();
   const propertyId = params.id as string;
 
   const [property, setProperty] = useState<PropertyWithStats | null>(null);
@@ -53,11 +52,7 @@ export default function PropertyDetailPage() {
   const [deleteRoom, setDeleteRoom] = useState<RoomWithTenant | null>(null);
   const [showEditProperty, setShowEditProperty] = useState(false);
 
-  useEffect(() => {
-    loadData();
-  }, [propertyId]);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       const [propertyRes, roomsRes] = await Promise.all([
         api.getProperty(propertyId),
@@ -70,7 +65,11 @@ export default function PropertyDetailPage() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [propertyId]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
 
   const formatCurrency = (amount: number, currencyCode: string = "UGX") => {
     const currency = CURRENCIES.find(c => c.code === currencyCode) || CURRENCIES[0];

--- a/frontend/src/app/dashboard/tenants/[id]/page.tsx
+++ b/frontend/src/app/dashboard/tenants/[id]/page.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
 import Link from "next/link";
 import api, { TenantWithDetails, Payment, PaymentStatus } from "@/lib/api";
 import {
-  User,
   ArrowLeft,
   Mail,
   Phone,
@@ -28,7 +27,6 @@ import {
 
 export default function TenantDetailPage() {
   const params = useParams();
-  const router = useRouter();
   const tenantId = params.id as string;
 
   const [tenant, setTenant] = useState<TenantWithDetails | null>(null);
@@ -42,11 +40,7 @@ export default function TenantDetailPage() {
   const [showEnablePortal, setShowEnablePortal] = useState(false);
   const [markPaidPayment, setMarkPaidPayment] = useState<Payment | null>(null);
 
-  useEffect(() => {
-    loadData();
-  }, [tenantId]);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       const res = await api.getTenant(tenantId);
       setTenant(res);
@@ -55,7 +49,11 @@ export default function TenantDetailPage() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [tenantId]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
 
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat("en-US", {

--- a/frontend/src/app/dashboard/tenants/page.tsx
+++ b/frontend/src/app/dashboard/tenants/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import api, { TenantWithDetails, PropertyWithStats } from "@/lib/api";
 import {
@@ -17,7 +17,6 @@ import {
   UserMinus,
   Pencil,
   X,
-  Clock,
   CreditCard,
 } from "lucide-react";
 
@@ -30,11 +29,7 @@ export default function TenantsPage() {
   const [showActiveOnly, setShowActiveOnly] = useState(true);
   const [showAddModal, setShowAddModal] = useState(false);
 
-  useEffect(() => {
-    loadData();
-  }, [filterProperty, showActiveOnly]);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       const [tenantsRes, propertiesRes] = await Promise.all([
         api.getTenants({
@@ -50,7 +45,11 @@ export default function TenantsPage() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [filterProperty, showActiveOnly]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
 
   const filteredTenants = tenants.filter(
     (tenant) =>
@@ -58,20 +57,6 @@ export default function TenantsPage() {
       tenant.email?.toLowerCase().includes(searchQuery.toLowerCase()) ||
       tenant.phone?.includes(searchQuery)
   );
-
-  const formatDate = (dateStr: string) => {
-    return new Date(dateStr).toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
-  };
-
-  const getPaymentStatus = (tenant: TenantWithDetails) => {
-    if (!tenant.payments || tenant.payments.length === 0) return null;
-    const latestPayment = tenant.payments[0];
-    return latestPayment.status;
-  };
 
   if (isLoading) {
     return (
@@ -226,7 +211,6 @@ export default function TenantsPage() {
             <TenantCard
               key={tenant.id}
               tenant={tenant}
-              onUpdate={loadData}
               style={{ animationDelay: `${(i + 3) * 0.05}s` }}
             />
           ))}
@@ -247,11 +231,9 @@ export default function TenantsPage() {
 
 function TenantCard({
   tenant,
-  onUpdate,
   style,
 }: {
   tenant: TenantWithDetails;
-  onUpdate: () => void;
   style?: React.CSSProperties;
 }) {
   const [showMenu, setShowMenu] = useState(false);
@@ -425,13 +407,7 @@ function AddTenantModal({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
 
-  useEffect(() => {
-    if (selectedProperty) {
-      loadRooms();
-    }
-  }, [selectedProperty]);
-
-  const loadRooms = async () => {
+  const loadRooms = useCallback(async () => {
     try {
       const res = await api.getRooms(selectedProperty);
       // Only show vacant rooms
@@ -444,7 +420,13 @@ function AddTenantModal({
     } catch (error) {
       console.error("Failed to load rooms:", error);
     }
-  };
+  }, [selectedProperty]);
+
+  useEffect(() => {
+    if (selectedProperty) {
+      void loadRooms();
+    }
+  }, [loadRooms, selectedProperty]);
 
   const handleSubmit = async () => {
     setError("");

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAuth } from "@/lib/auth-context";
-import { Building2, Mail, Lock, User, Phone, AlertCircle, Check, Eye, EyeOff, ChevronDown } from "lucide-react";
+import { Building2, Mail, Lock, User, AlertCircle, Check, Eye, EyeOff, ChevronDown } from "lucide-react";
 
 // Country codes with flags
 const countryCodes = [

--- a/frontend/src/app/tenant/dashboard/page.tsx
+++ b/frontend/src/app/tenant/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import api, { Payment, TenantPortalResponse, PaymentStatus, PaymentDispute, LeaseAgreement } from "@/lib/api";
@@ -42,11 +42,7 @@ export default function TenantDashboardPage() {
 
   const normalizeStatus = (status: PaymentStatus) => String(status).toUpperCase();
 
-  useEffect(() => {
-    loadData();
-  }, [router]);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       const [profile, paymentsData] = await Promise.all([
         api.getTenantMe(),
@@ -62,7 +58,11 @@ export default function TenantDashboardPage() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [router]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
 
   const handleLogout = async () => {
     await api.tenantLogout().catch(() => {});
@@ -385,7 +385,7 @@ function LeaseSection() {
     try {
       const leaseData = await api.getMyLease();
       setLease(leaseData);
-    } catch (err) {
+    } catch {
       // No lease found is okay
       setLease(null);
     } finally {
@@ -404,7 +404,7 @@ function LeaseSection() {
       a.click();
       window.URL.revokeObjectURL(url);
       document.body.removeChild(a);
-    } catch (err) {
+    } catch {
       setError("Failed to download lease");
     }
   };

--- a/frontend/src/app/tenant/login/page.tsx
+++ b/frontend/src/app/tenant/login/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import api from "@/lib/api";
 import { Building2, Mail, Lock, AlertCircle, ArrowRight, Eye, EyeOff } from "lucide-react";
 

--- a/frontend/src/app/tenant/setup/page.tsx
+++ b/frontend/src/app/tenant/setup/page.tsx
@@ -4,7 +4,7 @@ import { useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import api from "@/lib/api";
-import { Building2, Key, Lock, AlertCircle, CheckCircle, ArrowRight } from "lucide-react";
+import { Key, Lock, AlertCircle, CheckCircle, ArrowRight } from "lucide-react";
 
 function TenantSetupContent() {
   const router = useRouter();
@@ -38,7 +38,7 @@ function TenantSetupContent() {
     setIsLoading(true);
 
     try {
-      const res = await api.tenantSetupPassword(token, password);
+      await api.tenantSetupPassword(token, password);
       // Automatically store token if returned, or handle login redirect
       // The backend response for setup-password returns the TenantPortalResponse (profile)
       // but NOT a fresh access token for login. The user needs to log in explicitly.

--- a/frontend/src/components/notification-bell.tsx
+++ b/frontend/src/components/notification-bell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
-import { Bell, Check, CheckCheck, X, ChevronRight, Loader2 } from "lucide-react";
+import { Bell, Check, CheckCheck, ChevronRight, Loader2 } from "lucide-react";
 import api, { NotificationItem } from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
 import Link from "next/link";

--- a/frontend/src/components/trend-chart.tsx
+++ b/frontend/src/components/trend-chart.tsx
@@ -130,10 +130,6 @@ export default function TrendChart({ data, currency }: TrendChartProps) {
     monthLabel: formatMonth(item.month),
   }));
 
-  // Get the primary color for the chart bars
-  const barColor = "var(--primary-500)";
-  const barColorHover = "var(--primary-600)";
-
   return (
     <div style={{ width: "100%", height: 240 }}>
       <ResponsiveContainer>


### PR DESCRIPTION
## Summary
- fix the maintenance dashboard search so typing a query actually refetches matching requests
- remove the remaining frontend lint warnings by cleaning unused imports/variables and stabilizing effect loaders with useCallback

## Validation
- cd frontend; npm run lint
- cd frontend; npm run build

## Risk
- low; the only intended behavior change is maintenance search refetching on query changes