### PR TITLE
chore(frontend): remove unused Stripe packages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,8 +9,6 @@
     "lint": "eslint src/"
   },
   "dependencies": {
-    "@stripe/react-stripe-js": "^5.4.1",
-    "@stripe/stripe-js": "^8.6.0",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
     "react": "19.2.3",


### PR DESCRIPTION
Removes @stripe/react-stripe-js and @stripe/stripe-js from package.json. These packages were leftovers from a previously reverted Stripe integration and are not imported anywhere in the codebase.