### PR TITLE
chore(config): dotenv-based config loading, email STARTTLS, and startup script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,19 @@
+# Database (production: PostgreSQL)
 DATABASE_URL=postgresql+psycopg://postgres:postgres@db:5432/landten
 POSTGRES_DB=landten
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD_FILE=./secrets/postgres_password.txt
+
+# JWT
 SECRET_KEY_FILE=./secrets/app_secret_key.txt
+
+# Frontend
 FRONTEND_URL=http://localhost:3000
 NEXT_PUBLIC_API_URL=http://localhost:8000/api
+
+# Email (Gmail SMTP — port 587 uses STARTTLS, port 465 uses TLS)
 MAIL_HOST=smtp.gmail.com
-MAIL_PORT=465
-MAIL_USERNAME=your-email@example.com
-MAIL_FROM=your-email@example.com
+MAIL_PORT=587
+MAIL_USERNAME=your-email@gmail.com
+MAIL_FROM=your-email@gmail.com
 MAIL_PASSWORD_FILE=./secrets/mail_password.txt

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,9 +1,18 @@
 from functools import lru_cache
+import os
 from pathlib import Path
 
+from dotenv import dotenv_values
 from pydantic_settings import BaseSettings
 
 BACKEND_DIR = Path(__file__).resolve().parents[2]
+_ENV_FILE = BACKEND_DIR / ".env"
+
+# Load .env values and patch OS env vars.
+# The project .env is the source of truth for local development.
+# Production deployments should set env vars explicitly.
+for key, value in dotenv_values(_ENV_FILE).items():
+    os.environ[key] = value
 
 
 def _read_secret_file(path_value: str) -> str:
@@ -37,7 +46,7 @@ class Settings(BaseSettings):
     MAIL_USERNAME_FILE: str = ""
     MAIL_PASSWORD: str = ""
     MAIL_PASSWORD_FILE: str = ""
-    MAIL_PORT: int = 465
+    MAIL_PORT: int = 587
     MAIL_FROM: str = ""
     MAIL_FROM_FILE: str = ""
 
@@ -56,7 +65,6 @@ class Settings(BaseSettings):
         self.MAIL_FROM = _resolve_secret(self.MAIL_FROM, self.MAIL_FROM_FILE)
 
     class Config:
-        env_file = ".env"
         extra = "ignore"
 
 

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -122,7 +122,8 @@ async def send_email(
             port=settings.MAIL_PORT,
             username=settings.MAIL_USERNAME,
             password=settings.MAIL_PASSWORD,
-            use_tls=True,  # Gmail requires TLS on port 465
+            use_tls=settings.MAIL_PORT == 465,
+            start_tls=settings.MAIL_PORT == 587,
         )
 
         logger.info(f"Email sent successfully to {to_email}")

--- a/backend/start.bat
+++ b/backend/start.bat
@@ -1,0 +1,7 @@
+@echo off
+REM Start LandTen backend (development mode)
+REM Config is loaded from .env by python-dotenv in app/core/config.py
+REM No manual env var setup needed.
+
+cd /d "%~dp0"
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000

--- a/frontend/.env.production.example
+++ b/frontend/.env.production.example
@@ -1,0 +1,2 @@
+# Production API URL (set to your deployed backend)
+NEXT_PUBLIC_API_URL=https://your-backend-domain.com/api


### PR DESCRIPTION
- **python-dotenv** loads \`.env\` BEFORE pydantic-settings, ensuring the project \`.env\` is always the source of truth even when OS env vars are stale (fixes \`MAIL_PORT=465\`, \`DATABASE_URL=postgres\` overrides).\n- **Email service** auto-detects TLS mode: STARTTLS on port 587, direct TLS on port 465. Default port changed to 587.\n- **backend/start.bat** for simple dev server startup.\n- **frontend/.env.production.example** for deployment config.\n- **.env.example** updated with correct email settings.\n\n### Email verified\nPayment reminder email sent successfully to \`kasuletrevor@gmail.com\` via \`marconi.elearn@gmail.com\` on port 587 STARTTLS.