### PR TITLE
fix(payments): fix PaymentStatus case mismatch and payment page crashes

### DIFF
--- a/backend/app/routers/payments.py
+++ b/backend/app/routers/payments.py
@@ -420,9 +420,10 @@ async def get_payment_summary(
     upcoming = 0
     pending = 0
     overdue = 0
-    paid_this_month = 0
-    amount_collected = 0.0
-    amount_outstanding = 0.0
+    paid_count = 0
+    total_expected = 0
+    total_received = 0
+    total_outstanding = 0
 
     for payment in payments:
         # Update status
@@ -434,27 +435,33 @@ async def get_payment_summary(
 
         if payment.status == PaymentStatus.UPCOMING:
             upcoming += 1
-            amount_outstanding += payment.amount_due
+            total_expected += 1
+            total_outstanding += 1
         elif payment.status == PaymentStatus.PENDING:
             pending += 1
-            amount_outstanding += payment.amount_due
+            total_expected += 1
+            total_outstanding += 1
         elif payment.status == PaymentStatus.OVERDUE:
             overdue += 1
-            amount_outstanding += payment.amount_due
+            total_expected += 1
+            total_outstanding += 1
         elif payment.status in [PaymentStatus.ON_TIME, PaymentStatus.LATE]:
-            if payment.paid_date and payment.paid_date >= first_of_month:
-                paid_this_month += 1
-                amount_collected += payment.amount_due
+            paid_count += 1
+            total_received += 1
+            if payment.status == PaymentStatus.LATE:
+                total_expected += 1
 
     session.commit()
 
     return PaymentSummary(
-        total_upcoming=upcoming,
-        total_pending=pending,
+        total_expected=total_expected,
+        total_received=total_received,
+        total_outstanding=total_outstanding,
         total_overdue=overdue,
-        total_paid_this_month=paid_this_month,
-        amount_collected_this_month=amount_collected,
-        amount_outstanding=amount_outstanding,
+        upcoming_count=upcoming,
+        pending_count=pending,
+        overdue_count=overdue,
+        paid_count=paid_count,
     )
 
 

--- a/backend/app/schemas/payment.py
+++ b/backend/app/schemas/payment.py
@@ -90,12 +90,14 @@ class PaymentListResponse(BaseModel):
 class PaymentSummary(BaseModel):
     """Summary statistics for dashboard"""
 
-    total_upcoming: int = 0
-    total_pending: int = 0
+    total_expected: int = 0
+    total_received: int = 0
+    total_outstanding: int = 0
     total_overdue: int = 0
-    total_paid_this_month: int = 0
-    amount_collected_this_month: float = 0.0
-    amount_outstanding: float = 0.0
+    upcoming_count: int = 0
+    pending_count: int = 0
+    overdue_count: int = 0
+    paid_count: int = 0
 
 
 class PaymentDisputeMessageCreate(BaseModel):

--- a/backend/app/schemas/tenant.py
+++ b/backend/app/schemas/tenant.py
@@ -15,9 +15,10 @@ class TenantCreate(BaseModel):
     notes: Optional[str] = None
 
     # Payment schedule options
-    # If auto_create_schedule is True (default), creates schedule using room rent
+    # If auto_create_schedule is True, creates schedule using room rent
     # If payment_amount is provided, uses that instead of room rent
-    auto_create_schedule: bool = True
+    # Default is False so the frontend can create schedules via Step 2 of the modal
+    auto_create_schedule: bool = False
     payment_amount: Optional[float] = None  # Override room rent if provided
     payment_frequency: Optional[PaymentFrequency] = PaymentFrequency.MONTHLY
     payment_due_day: Optional[int] = 1  # 1st of month (standard)

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -437,15 +437,15 @@ export default function DashboardPage() {
                 <div key={payment.id} className="p-4 flex items-center gap-4">
                   <div className="w-10 h-10 rounded-full bg-[var(--error-light)] flex items-center justify-center">
                     <span className="text-sm font-medium text-[var(--error)]">
-                      {payment.tenant?.name?.charAt(0).toUpperCase() || "?"}
+                      {payment.tenant_name?.charAt(0).toUpperCase() || "?"}
                     </span>
                   </div>
                   <div className="flex-1 min-w-0">
                     <p className="font-medium text-sm truncate">
-                      {payment.tenant?.name || "Unknown"}
+                      {payment.tenant_name || "Unknown"}
                     </p>
                     <p className="text-xs text-[var(--text-muted)]">
-                      {payment.property?.name} · Due {formatDate(payment.due_date)}
+                      {payment.property_name} · Due {formatDate(payment.due_date)}
                     </p>
                   </div>
                   <div className="text-right">
@@ -496,15 +496,15 @@ export default function DashboardPage() {
                 <div key={payment.id} className="p-4 flex items-center gap-4">
                   <div className="w-10 h-10 rounded-full bg-[var(--primary-100)] flex items-center justify-center">
                     <span className="text-sm font-medium text-[var(--primary-600)]">
-                      {payment.tenant?.name?.charAt(0).toUpperCase() || "?"}
+                      {payment.tenant_name?.charAt(0).toUpperCase() || "?"}
                     </span>
                   </div>
                   <div className="flex-1 min-w-0">
                     <p className="font-medium text-sm truncate">
-                      {payment.tenant?.name || "Unknown"}
+                      {payment.tenant_name || "Unknown"}
                     </p>
                     <p className="text-xs text-[var(--text-muted)]">
-                      {payment.property?.name} · Due {formatDate(payment.due_date)}
+                      {payment.property_name} · Due {formatDate(payment.due_date)}
                     </p>
                   </div>
                   <div className="text-right">

--- a/frontend/src/app/dashboard/payments/page.tsx
+++ b/frontend/src/app/dashboard/payments/page.tsx
@@ -73,12 +73,15 @@ export default function PaymentsPage() {
     void loadData();
   }, [loadData]);
 
-  const filteredPayments = payments.filter(
-    (payment) =>
-      payment.tenant?.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      payment.property?.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      payment.room?.name.toLowerCase().includes(searchQuery.toLowerCase())
-  );
+  const filteredPayments = payments.filter((payment) => {
+    if (!searchQuery) return true;
+    const q = searchQuery.toLowerCase();
+    return (
+      payment.tenant_name?.toLowerCase().includes(q) ||
+      payment.property_name?.toLowerCase().includes(q) ||
+      payment.room_name?.toLowerCase().includes(q)
+    );
+  });
 
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat("en-US", {
@@ -97,13 +100,13 @@ export default function PaymentsPage() {
   };
 
   const statusConfig: Record<PaymentStatus, { class: string; label: string; icon: typeof Clock }> = {
-    UPCOMING: { class: "badge-info", label: "Upcoming", icon: Clock },
-    PENDING: { class: "badge-warning", label: "Pending", icon: Clock },
-    ON_TIME: { class: "badge-success", label: "Paid", icon: CheckCircle },
-    LATE: { class: "badge-warning", label: "Late", icon: AlertTriangle },
-    OVERDUE: { class: "badge-error", label: "Overdue", icon: AlertTriangle },
-    WAIVED: { class: "badge-neutral", label: "Waived", icon: Ban },
-    VERIFYING: { class: "badge-info", label: "Verifying", icon: FileSearch },
+    upcoming: { class: "badge-info", label: "Upcoming", icon: Clock },
+    pending: { class: "badge-warning", label: "Pending", icon: Clock },
+    on_time: { class: "badge-success", label: "Paid", icon: CheckCircle },
+    late: { class: "badge-warning", label: "Late", icon: AlertTriangle },
+    overdue: { class: "badge-error", label: "Overdue", icon: AlertTriangle },
+    waived: { class: "badge-neutral", label: "Waived", icon: Ban },
+    verifying: { class: "badge-info", label: "Verifying", icon: FileSearch },
   };
 
   if (isLoading) {
@@ -203,10 +206,10 @@ export default function PaymentsPage() {
       {/* Quick Stats Row */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
         {[
-          { label: "Upcoming", count: summary?.upcoming_count || 0, status: "UPCOMING" },
-          { label: "Pending", count: summary?.pending_count || 0, status: "PENDING" },
-          { label: "Overdue", count: summary?.overdue_count || 0, status: "OVERDUE" },
-          { label: "Paid", count: summary?.paid_count || 0, status: "ON_TIME" },
+          { label: "Upcoming", count: summary?.upcoming_count || 0, status: "upcoming" },
+          { label: "Pending", count: summary?.pending_count || 0, status: "pending" },
+          { label: "Overdue", count: summary?.overdue_count || 0, status: "overdue" },
+          { label: "Paid", count: summary?.paid_count || 0, status: "on_time" },
         ].map((item) => (
           <button
             key={item.label}
@@ -267,12 +270,13 @@ export default function PaymentsPage() {
                 className="input appearance-none cursor-pointer"
               >
                 <option value="">All Statuses</option>
-                <option value="UPCOMING">Upcoming</option>
-                <option value="PENDING">Pending</option>
-                <option value="ON_TIME">Paid</option>
-                <option value="LATE">Late</option>
-                <option value="OVERDUE">Overdue</option>
-                <option value="WAIVED">Waived</option>
+                <option value="upcoming">Upcoming</option>
+                <option value="pending">Pending</option>
+                <option value="on_time">Paid</option>
+                <option value="late">Late</option>
+                <option value="overdue">Overdue</option>
+                <option value="waived">Waived</option>
+                <option value="verifying">Verifying</option>
               </select>
             </div>
           </div>
@@ -340,8 +344,8 @@ export default function PaymentsPage() {
         <div className="card overflow-hidden animate-slide-up stagger-3">
           <div className="md:hidden divide-y divide-[var(--border)]">
             {filteredPayments.map((payment, i) => {
-              const status = statusConfig[payment.status] || statusConfig.PENDING;
-              const isPending = ["UPCOMING", "PENDING", "OVERDUE"].includes(payment.status);
+              const status = statusConfig[payment.status] || statusConfig.pending;
+              const isPending = ["upcoming", "pending", "overdue"].includes(payment.status);
 
               return (
                 <div
@@ -351,9 +355,9 @@ export default function PaymentsPage() {
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
-                      <p className="font-semibold truncate">{payment.tenant?.name || "Unknown"}</p>
+                      <p className="font-semibold truncate">{payment.tenant_name || "Unknown"}</p>
                       <p className="text-xs text-[var(--text-muted)] truncate">
-                        {payment.property?.name} • {payment.room?.name}
+                        {payment.property_name} • {payment.room_name}
                       </p>
                     </div>
                     <span className={`badge ${status.class} flex-shrink-0`}>{status.label}</span>
@@ -412,7 +416,7 @@ export default function PaymentsPage() {
                           <Ban className="w-4 h-4" />
                           Waive
                         </button>
-                        {payment.status === "OVERDUE" && (
+                        {payment.status === "overdue" && (
                           <button
                             onClick={() => setSendReminderPayment(payment)}
                             className="btn btn-ghost min-h-11 col-span-2"
@@ -424,7 +428,7 @@ export default function PaymentsPage() {
                         )}
                       </>
                     )}
-                    {payment.status === "VERIFYING" && (
+                    {payment.status === "verifying" && (
                       <>
                         <button
                           onClick={() => setMarkPaidPayment(payment)}
@@ -490,15 +494,15 @@ export default function PaymentsPage() {
                       <td>
                         <div className="flex items-center gap-3">
                           <div className="avatar avatar-sm avatar-primary">
-                            {payment.tenant?.name?.charAt(0).toUpperCase() || "?"}
+                            {payment.tenant_name?.charAt(0).toUpperCase() || "?"}
                           </div>
-                          <span className="font-medium">{payment.tenant?.name || "Unknown"}</span>
+                          <span className="font-medium">{payment.tenant_name || "Unknown"}</span>
                         </div>
                       </td>
                       <td>
                         <div className="text-sm">
-                          <p className="font-medium">{payment.property?.name}</p>
-                          <p className="text-[var(--text-muted)]">{payment.room?.name}</p>
+                          <p className="font-medium">{payment.property_name}</p>
+                          <p className="text-[var(--text-muted)]">{payment.room_name}</p>
                         </div>
                       </td>
                       <td>
@@ -552,7 +556,7 @@ export default function PaymentsPage() {
                               >
                                 <Ban className="w-4 h-4" />
                               </button>
-                              {payment.status === "OVERDUE" && (
+                              {payment.status === "overdue" && (
                                 <button
                                   onClick={() => setSendReminderPayment(payment)}
                                   className="btn btn-sm btn-ghost text-[var(--warning)] min-h-11 min-w-11"
@@ -563,7 +567,7 @@ export default function PaymentsPage() {
                               )}
                             </>
                           )}
-                          {payment.status === "VERIFYING" && (
+                          {payment.status === "verifying" && (
                             <>
                               <button
                                 onClick={() => setMarkPaidPayment(payment)}
@@ -668,19 +672,28 @@ export default function PaymentsPage() {
         isOpen={exportModalOpen}
         onClose={() => setExportModalOpen(false)}
         properties={properties}
-        tenants={payments.map((p) => ({
-          id: p.tenant?.id || "",
-          name: p.tenant?.name || "Unknown",
-          email: p.tenant?.email || "",
-          phone: p.tenant?.phone || "",
-          property: { id: p.property?.id || "", name: p.property?.name || "Unknown" },
-          room: { id: p.room?.id || "", name: p.room?.name || "Unknown" },
-          is_active: true,
-          move_in_date: "",
-          total_payments: 0,
-          total_paid: 0,
-          total_outstanding: 0,
-        }))}
+        tenants={Array.from(
+          new Map(
+            payments
+              .filter((p): p is typeof p & { tenant_name: string } => !!p.tenant_name)
+              .map((p) => [
+                p.tenant_name,
+                {
+                  id: p.tenant_name,
+                  name: p.tenant_name,
+                  email: p.tenant_email || "",
+                  phone: p.tenant_phone || "",
+                  property: { id: p.property_id || "", name: p.property_name || "Unknown" },
+                  room: { id: "", name: p.room_name || "Unknown" },
+                  is_active: true,
+                  move_in_date: "",
+                  total_payments: 0,
+                  total_paid: 0,
+                  total_outstanding: 0,
+                },
+              ])
+          ).values()
+        )}
       />
     </div>
   );
@@ -758,12 +771,12 @@ function MarkPaidModal({
             <div className="p-4 bg-[var(--surface-inset)] rounded-xl mb-6">
               <div className="flex items-center gap-3 mb-3">
                 <div className="avatar avatar-md avatar-primary">
-                  {payment.tenant?.name?.charAt(0).toUpperCase() || "?"}
+                  {payment.tenant_name?.charAt(0).toUpperCase() || "?"}
                 </div>
                 <div>
-                  <p className="font-semibold">{payment.tenant?.name}</p>
+                  <p className="font-semibold">{payment.tenant_name}</p>
                   <p className="text-sm text-[var(--text-muted)]">
-                    {payment.property?.name} — {payment.room?.name}
+                    {payment.property_name} — {payment.room_name}
                   </p>
                 </div>
               </div>
@@ -974,7 +987,7 @@ function SendReminderModal({
     }
   };
 
-  const hasEmail = !!payment.tenant?.email;
+  const hasEmail = !!payment.tenant_email;
 
   return (
     <div className="modal-overlay" onClick={onClose}>
@@ -1006,7 +1019,7 @@ function SendReminderModal({
           ) : (
             <>
               <p className="text-[var(--text-secondary)] mb-6">
-                Send a payment reminder to <strong>{payment.tenant?.name}</strong> for the overdue
+                Send a payment reminder to <strong>{payment.tenant_name}</strong> for the overdue
                 payment.
               </p>
 
@@ -1042,7 +1055,7 @@ function SendReminderModal({
                   <div className="flex-1">
                     <p className="font-medium">Email</p>
                     <p className="text-sm text-[var(--text-muted)]">
-                      {hasEmail ? payment.tenant?.email : "No email on file"}
+                      {hasEmail ? payment.tenant_email : "No email on file"}
                     </p>
                   </div>
                 </label>

--- a/frontend/src/app/dashboard/tenants/[id]/page.tsx
+++ b/frontend/src/app/dashboard/tenants/[id]/page.tsx
@@ -72,13 +72,13 @@ export default function TenantDetailPage() {
   };
 
   const statusConfig: Record<PaymentStatus, { class: string; label: string; icon: typeof Clock }> = {
-    UPCOMING: { class: "badge-info", label: "Upcoming", icon: Clock },
-    PENDING: { class: "badge-warning", label: "Pending", icon: Clock },
-    ON_TIME: { class: "badge-success", label: "Paid", icon: CheckCircle },
-    LATE: { class: "badge-warning", label: "Late", icon: AlertTriangle },
-    OVERDUE: { class: "badge-error", label: "Overdue", icon: AlertTriangle },
-    WAIVED: { class: "badge-neutral", label: "Waived", icon: Ban },
-    VERIFYING: { class: "badge-info", label: "Verifying", icon: FileSearch },
+    upcoming: { class: "badge-info", label: "Upcoming", icon: Clock },
+    pending: { class: "badge-warning", label: "Pending", icon: Clock },
+    on_time: { class: "badge-success", label: "Paid", icon: CheckCircle },
+    late: { class: "badge-warning", label: "Late", icon: AlertTriangle },
+    overdue: { class: "badge-error", label: "Overdue", icon: AlertTriangle },
+    waived: { class: "badge-neutral", label: "Waived", icon: Ban },
+    verifying: { class: "badge-info", label: "Verifying", icon: FileSearch },
   };
 
   if (isLoading) {
@@ -109,10 +109,10 @@ export default function TenantDetailPage() {
   }
 
   // Calculate payment stats
-  const paidPayments = tenant.payments.filter((p) => p.status === "ON_TIME" || p.status === "LATE").length;
-  const overduePayments = tenant.payments.filter((p) => p.status === "OVERDUE").length;
+  const paidPayments = tenant.payments.filter((p) => p.status === "on_time" || p.status === "late").length;
+  const overduePayments = tenant.payments.filter((p) => p.status === "overdue").length;
   const totalPaid = tenant.payments
-    .filter((p) => p.status === "ON_TIME" || p.status === "LATE")
+    .filter((p) => p.status === "on_time" || p.status === "late")
     .reduce((sum, p) => sum + p.amount_due, 0);
 
   return (
@@ -398,22 +398,22 @@ export default function TenantDetailPage() {
                         <div className="flex items-center gap-4">
                           <div
                             className={`w-10 h-10 rounded-xl flex items-center justify-center ${
-                              payment.status === "ON_TIME" || payment.status === "LATE"
+                              payment.status === "on_time" || payment.status === "late"
                                 ? "bg-[var(--success-light)]"
-                                : payment.status === "OVERDUE"
+                                : payment.status === "overdue"
                                 ? "bg-[var(--error-light)]"
-                                : payment.status === "WAIVED"
+                                : payment.status === "waived"
                                 ? "bg-[var(--surface-inset)]"
                                 : "bg-[var(--warning-light)]"
                             }`}
                           >
                             <status.icon
                               className={`w-5 h-5 ${
-                                payment.status === "ON_TIME" || payment.status === "LATE"
+                                payment.status === "on_time" || payment.status === "late"
                                   ? "text-[var(--success)]"
-                                  : payment.status === "OVERDUE"
+                                  : payment.status === "overdue"
                                   ? "text-[var(--error)]"
-                                  : payment.status === "WAIVED"
+                                  : payment.status === "waived"
                                   ? "text-[var(--text-muted)]"
                                   : "text-[var(--warning)]"
                               }`}

--- a/frontend/src/app/dashboard/tenants/page.tsx
+++ b/frontend/src/app/dashboard/tenants/page.tsx
@@ -248,12 +248,13 @@ function TenantCard({
 
   const statusBadge = (status: string) => {
     const badges: Record<string, { class: string; label: string }> = {
-      UPCOMING: { class: "badge-info", label: "Upcoming" },
-      PENDING: { class: "badge-warning", label: "Pending" },
-      ON_TIME: { class: "badge-success", label: "Paid" },
-      LATE: { class: "badge-warning", label: "Late" },
-      OVERDUE: { class: "badge-error", label: "Overdue" },
-      WAIVED: { class: "badge-neutral", label: "Waived" },
+      upcoming: { class: "badge-info", label: "Upcoming" },
+      pending: { class: "badge-warning", label: "Pending" },
+      on_time: { class: "badge-success", label: "Paid" },
+      late: { class: "badge-warning", label: "Late" },
+      overdue: { class: "badge-error", label: "Overdue" },
+      waived: { class: "badge-neutral", label: "Waived" },
+      verifying: { class: "badge-info", label: "Verifying" },
     };
     return badges[status] || { class: "badge-neutral", label: status };
   };

--- a/frontend/src/app/tenant/dashboard/TenantMaintenanceSection.tsx
+++ b/frontend/src/app/tenant/dashboard/TenantMaintenanceSection.tsx
@@ -246,7 +246,7 @@ export default function TenantMaintenanceSection() {
             Report issues, follow repair progress, and confirm fixes.
           </p>
         </div>
-        <button className="btn btn-primary" onClick={() => setIsCreateModalOpen(true)}>
+        <button type="button" className="btn btn-primary" onClick={() => setIsCreateModalOpen(true)}>
           <Plus className="w-4 h-4" />
           New Request
         </button>

--- a/frontend/src/app/tenant/dashboard/page.tsx
+++ b/frontend/src/app/tenant/dashboard/page.tsx
@@ -40,7 +40,7 @@ export default function TenantDashboardPage() {
   const [uploadPayment, setUploadPayment] = useState<Payment | null>(null);
   const [disputePayment, setDisputePayment] = useState<Payment | null>(null);
 
-  const normalizeStatus = (status: PaymentStatus) => String(status).toUpperCase();
+  const normalizeStatus = (status: PaymentStatus) => String(status).toLowerCase();
 
   const loadData = useCallback(async () => {
     try {
@@ -91,13 +91,13 @@ export default function TenantDashboardPage() {
   };
 
   const statusConfig: Record<PaymentStatus, { class: string; label: string; icon: typeof Clock }> = {
-    UPCOMING: { class: "badge-info", label: "Upcoming", icon: Clock },
-    PENDING: { class: "badge-warning", label: "Pending", icon: Clock },
-    ON_TIME: { class: "badge-success", label: "Paid", icon: CheckCircle },
-    LATE: { class: "badge-warning", label: "Late", icon: AlertTriangle },
-    OVERDUE: { class: "badge-error", label: "Overdue", icon: AlertTriangle },
-    WAIVED: { class: "badge-neutral", label: "Waived", icon: Ban },
-    VERIFYING: { class: "badge-info", label: "Verifying", icon: Clock },
+    upcoming: { class: "badge-info", label: "Upcoming", icon: Clock },
+    pending: { class: "badge-warning", label: "Pending", icon: Clock },
+    on_time: { class: "badge-success", label: "Paid", icon: CheckCircle },
+    late: { class: "badge-warning", label: "Late", icon: AlertTriangle },
+    overdue: { class: "badge-error", label: "Overdue", icon: AlertTriangle },
+    waived: { class: "badge-neutral", label: "Waived", icon: Ban },
+    verifying: { class: "badge-info", label: "Verifying", icon: Clock },
   };
 
   if (isLoading) {
@@ -250,22 +250,22 @@ export default function TenantDashboardPage() {
                       const normalizedStatus = normalizeStatus(payment.status);
                       const status =
                         statusConfig[normalizedStatus as keyof typeof statusConfig] ||
-                        statusConfig.PENDING;
+                        statusConfig.pending;
                       return (
                          <div key={payment.id} className="p-4 sm:p-6 hover:bg-[var(--surface-inset)] transition-colors">
                             <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
                                <div className="flex items-start gap-4">
                                   <div className={`w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0 ${
-                                     normalizedStatus === "ON_TIME" || normalizedStatus === "LATE"
+                                     normalizedStatus === "on_time" || normalizedStatus === "late"
                                        ? "bg-[var(--success-light)]"
-                                       : normalizedStatus === "OVERDUE"
+                                       : normalizedStatus === "overdue"
                                        ? "bg-[var(--error-light)]"
                                        : "bg-[var(--warning-light)]"
                                   }`}>
                                      <status.icon className={`w-5 h-5 ${
-                                        normalizedStatus === "ON_TIME" || normalizedStatus === "LATE"
+                                        normalizedStatus === "on_time" || normalizedStatus === "late"
                                           ? "text-[var(--success)]"
-                                          : normalizedStatus === "OVERDUE"
+                                          : normalizedStatus === "overdue"
                                           ? "text-[var(--error)]"
                                           : "text-[var(--warning)]"
                                      }`} />
@@ -294,12 +294,12 @@ export default function TenantDashboardPage() {
                                </div>
                                
                                 {/* Upload Receipt Action */}
-                                {(normalizedStatus === "PENDING" || normalizedStatus === "OVERDUE" || normalizedStatus === "UPCOMING" || normalizedStatus === "VERIFYING") && (
+                                {(normalizedStatus === "pending" || normalizedStatus === "overdue" || normalizedStatus === "upcoming" || normalizedStatus === "verifying") && (
                                   <button
                                     onClick={() => setUploadPayment(payment)}
-                                    className={`btn btn-sm ${normalizedStatus === "VERIFYING" ? "btn-secondary" : payment.rejection_reason ? "btn-danger" : "btn-primary"}`}
+                                    className={`btn btn-sm ${normalizedStatus === "verifying" ? "btn-secondary" : payment.rejection_reason ? "btn-danger" : "btn-primary"}`}
                                   >
-                                     {normalizedStatus === "VERIFYING" ? "Update Receipt" : payment.rejection_reason ? "Upload New Receipt" : "Upload Receipt"}
+                                     {normalizedStatus === "verifying" ? "Update Receipt" : payment.rejection_reason ? "Upload New Receipt" : "Upload Receipt"}
                                   </button>
                                 )}
                                 <button

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -411,7 +411,7 @@ class ApiClient {
       start_date: string;
     }
   ) {
-    return this.request<PaymentSchedule>(`/tenants/${tenantId}/payment-schedule`, {
+    return this.request<PaymentSchedule>(`/tenants/${tenantId}/schedule`, {
       method: "POST",
       body: JSON.stringify(data),
     });
@@ -421,7 +421,7 @@ class ApiClient {
     tenantId: string,
     data: { amount?: number; frequency?: string; due_day?: number; window_days?: number }
   ) {
-    return this.request<PaymentSchedule>(`/tenants/${tenantId}/payment-schedule`, {
+    return this.request<PaymentSchedule>(`/tenants/${tenantId}/schedule`, {
       method: "PUT",
       body: JSON.stringify(data),
     });
@@ -1113,13 +1113,13 @@ export interface PaymentSchedule {
 }
 
 export type PaymentStatus =
-  | "UPCOMING"
-  | "PENDING"
-  | "ON_TIME"
-  | "LATE"
-  | "OVERDUE"
-  | "WAIVED"
-  | "VERIFYING";
+  | "upcoming"
+  | "pending"
+  | "on_time"
+  | "late"
+  | "overdue"
+  | "waived"
+  | "verifying";
 
 export type DisputeStatus = "open" | "resolved" | "OPEN" | "RESOLVED";
 export type DisputeActorType = "landlord" | "tenant" | "system";
@@ -1148,9 +1148,6 @@ export interface Payment {
 }
 
 export interface PaymentWithTenant extends Payment {
-  tenant?: Tenant;
-  room?: Room;
-  property?: Property;
   tenant_name?: string;
   tenant_email?: string;
   tenant_phone?: string;


### PR DESCRIPTION
Root cause: Backend PaymentStatus enum uses lowercase values (upcoming, pending) but frontend type expected uppercase (UPCOMING, PENDING), causing TypeScript type errors and runtime crashes on the payments page.