### PR TITLE
fix(auth): skip /me probe when no token in storage

### DIFF
--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -37,6 +37,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // Check for existing session on mount
   useEffect(() => {
+    // Skip the probe entirely if there is no token in storage.
+    // This avoids spurious 401s on every page load before the user logs in.
+    if (!api.getToken()) {
+      setIsLoading(false);
+      return;
+    }
+
     // Cookie-backed session restore:
     // first try landlord profile, then tenant profile.
     api.getMe()


### PR DESCRIPTION
The AuthContext unconditionally called \/api/auth/me\ (and fell through to \/api/tenant-auth/me\) on every page mount, generating a 401 in the console on every page load before the user logged in.

Fix: skip the probe entirely if there is no token in localStorage. The cookie-based auth flow still works because the backend accepts the HttpOnly cookie for all authenticated endpoints, and the dashboard/tenant pages will redirect to login if no user state is set.