### PR TITLE
feat(frontend): revamp auth pages and fix z-index issues

### DIFF
--- a/frontend/src/app/dashboard/properties/[id]/page.tsx
+++ b/frontend/src/app/dashboard/properties/[id]/page.tsx
@@ -215,7 +215,7 @@ export default function PropertyDetailPage() {
       </div>
 
       {/* Rooms Section */}
-      <div className="flex items-center justify-between mb-6 animate-slide-up stagger-1">
+      <div className="flex items-center justify-between mb-6 animate-slide-up stagger-1 relative z-20">
         <div>
           <h2
             className="text-xl font-semibold"
@@ -246,10 +246,10 @@ export default function PropertyDetailPage() {
           {showRoomDropdown && (
             <>
               <div
-                className="fixed inset-0 z-10"
+                className="fixed inset-0 z-40"
                 onClick={() => setShowRoomDropdown(false)}
               />
-              <div className="absolute right-0 top-full mt-1 w-48 bg-[var(--surface)] border border-[var(--border)] rounded-lg shadow-lg z-20">
+              <div className="absolute right-0 top-full mt-1 w-48 bg-[var(--surface)] border border-[var(--border)] rounded-lg shadow-lg z-50">
                 <button
                   onClick={() => {
                     setShowAddRoom(true);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -207,7 +207,7 @@ a:hover { color: var(--primary-700); }
   box-shadow: var(--shadow-sm);
   transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
-  overflow: hidden;
+  /* overflow: hidden; removed so dropdowns can break out */
 }
 
 .card::before {

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -4,12 +4,22 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAuth } from "@/lib/auth-context";
-import { Building2, Mail, Lock, AlertCircle, Eye, EyeOff } from "lucide-react";
+import { AuthSplitLayout } from "@/components/auth/AuthSplitLayout";
+import {
+  Mail,
+  Lock,
+  User,
+  AlertCircle,
+  Eye,
+  EyeOff,
+  ArrowRight,
+} from "lucide-react";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
+  const [rememberMe, setRememberMe] = useState(false);
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const { login } = useAuth();
@@ -31,136 +41,144 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex bg-[var(--background)]">
-      {/* Left side - Form */}
-      <div className="flex-1 flex items-center justify-center p-8">
-        <div className="w-full max-w-md animate-fade-in">
-          <Link href="/" className="flex items-center gap-2 mb-8">
-            <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-[var(--primary-500)] to-[var(--primary-700)] flex items-center justify-center">
-              <Building2 className="w-4 h-4 text-white" />
-            </div>
-            <span className="font-semibold text-lg" style={{ fontFamily: "var(--font-outfit)" }}>
-              LandTen
-            </span>
+    <AuthSplitLayout
+      footer={
+        <>
+          By signing in, you agree to our{" "}
+          <Link href="#" className="text-[var(--primary-400)] hover:underline">
+            Terms of Service
+          </Link>{" "}
+          and{" "}
+          <Link href="#" className="text-[var(--primary-400)] hover:underline">
+            Privacy Policy
           </Link>
-
-          <h1
-            className="text-3xl font-bold mb-2"
-            style={{ fontFamily: "var(--font-outfit)" }}
-          >
-            Welcome back
-          </h1>
-          <p className="text-[var(--text-secondary)] mb-8">
-            Sign in to your account to continue managing your properties.
-          </p>
-
-          {error && (
-            <div className="flex items-center gap-2 p-3 mb-6 bg-[var(--error-light)] text-[var(--error)] rounded-lg text-sm animate-slide-down">
-              <AlertCircle className="w-4 h-4 flex-shrink-0" />
-              {error}
-            </div>
-          )}
-
-          <form onSubmit={handleSubmit} className="space-y-5">
-            <div>
-              <label htmlFor="email" className="label">
-                Email address
-              </label>
-              <div className="relative">
-                <Mail className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--text-muted)] pointer-events-none" />
-                <input
-                  id="email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="input !pl-14"
-                  placeholder="you@example.com"
-                  required
-                />
-              </div>
-            </div>
-
-            <div>
-              <label htmlFor="password" className="label">
-                Password
-              </label>
-              <div className="relative">
-                <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--text-muted)] pointer-events-none" />
-                <input
-                  id="password"
-                  type={showPassword ? "text" : "password"}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="input !pl-14 !pr-12"
-                  placeholder="Enter your password"
-                  required
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
-                >
-                  {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
-                </button>
-              </div>
-            </div>
-
-            <button
-              type="submit"
-              disabled={isLoading}
-              className="btn btn-primary w-full py-3"
-            >
-              {isLoading ? (
-                <>
-                  <div className="spinner" />
-                  Signing in...
-                </>
-              ) : (
-                "Sign in"
-              )}
-            </button>
-          </form>
-
-          <p className="mt-6 text-center text-sm text-[var(--text-secondary)]">
-            Don&apos;t have an account?{" "}
-            <Link href="/register" className="font-medium text-[var(--primary-600)] hover:text-[var(--primary-700)]">
-              Create one
-            </Link>
-          </p>
+          .
+        </>
+      }
+    >
+      <div className="text-center">
+        <div className="w-14 h-14 mx-auto mb-5 rounded-full bg-white/5 border border-white/10 flex items-center justify-center">
+          <User className="w-6 h-6 text-[var(--primary-400)]" />
         </div>
+        <h1
+          className="text-3xl font-bold text-white mb-2"
+          style={{ fontFamily: "var(--font-outfit)" }}
+        >
+          Welcome back
+        </h1>
+        <p className="text-[var(--text-secondary)] text-sm">
+          Sign in to your LandTen account to continue managing your properties.
+        </p>
       </div>
 
-      {/* Right side - Image/Pattern */}
-      <div className="hidden lg:flex flex-1 items-center justify-center bg-gradient-to-br from-[var(--primary-500)] to-[var(--primary-800)] p-12">
-        <div className="max-w-md text-white">
-          <h2
-            className="text-3xl font-bold mb-4"
-            style={{ fontFamily: "var(--font-outfit)" }}
-          >
-            Manage your properties with ease
-          </h2>
-          <p className="text-[var(--primary-100)] mb-8">
-            Track payments, manage tenants, and stay organized with LandTen&apos;s
-            intuitive property management platform.
-          </p>
-          <div className="grid grid-cols-2 gap-4">
-            {[
-              "Payment tracking",
-              "Tenant management",
-              "Multi-property support",
-              "Real-time notifications",
-            ].map((feature) => (
-              <div
-                key={feature}
-                className="flex items-center gap-2 text-sm text-[var(--primary-100)]"
-              >
-                <div className="w-1.5 h-1.5 rounded-full bg-white" />
-                {feature}
-              </div>
-            ))}
+      {error && (
+        <div className="mt-6 flex items-center gap-2 p-3 bg-[var(--error)]/10 border border-[var(--error)]/20 text-[var(--error)] rounded-xl text-sm animate-slide-down">
+          <AlertCircle className="w-4 h-4 flex-shrink-0" />
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="mt-8 space-y-5">
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+            Email address
+          </label>
+          <div className="relative">
+            <Mail className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--text-muted)] pointer-events-none" />
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full bg-white/5 border border-white/10 rounded-xl py-3 pl-13 pr-4 text-white placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--primary-500)] focus:ring-1 focus:ring-[var(--primary-500)] transition-all"
+              placeholder="you@example.com"
+              required
+              autoComplete="email"
+            />
           </div>
         </div>
-      </div>
-    </div>
+
+        <div>
+          <label htmlFor="password" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+            Password
+          </label>
+          <div className="relative">
+            <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--text-muted)] pointer-events-none" />
+            <input
+              id="password"
+              type={showPassword ? "text" : "password"}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full bg-white/5 border border-white/10 rounded-xl py-3 pl-13 pr-12 text-white placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--primary-500)] focus:ring-1 focus:ring-[var(--primary-500)] transition-all"
+              placeholder="Enter your password"
+              required
+              autoComplete="current-password"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword(!showPassword)}
+              className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-white transition-colors"
+            >
+              {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+            </button>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <label className="flex items-center gap-2 cursor-pointer group">
+            <input
+              type="checkbox"
+              checked={rememberMe}
+              onChange={(e) => setRememberMe(e.target.checked)}
+              className="w-4 h-4 rounded border-white/20 bg-white/5 text-[var(--primary-500)] focus:ring-[var(--primary-500)] focus:ring-offset-0"
+            />
+            <span className="text-sm text-[var(--text-secondary)] group-hover:text-white transition-colors">
+              Remember me
+            </span>
+          </label>
+          <Link
+            href="#"
+            className="text-sm font-medium text-[var(--primary-400)] hover:text-[var(--primary-300)] transition-colors"
+          >
+            Forgot password?
+          </Link>
+        </div>
+
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full py-3 px-4 rounded-xl bg-gradient-to-r from-[var(--primary-500)] to-[var(--primary-600)] text-white font-medium flex items-center justify-center gap-2 hover:from-[var(--primary-400)] hover:to-[var(--primary-500)] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isLoading ? (
+            <>
+              <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              Signing in...
+            </>
+          ) : (
+            <>
+              Sign in
+              <ArrowRight className="w-4 h-4" />
+            </>
+          )}
+        </button>
+
+        <div className="relative flex items-center justify-center">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-white/10" />
+          </div>
+          <span className="relative px-3 bg-[var(--neutral-950)] text-xs text-[var(--text-muted)]">
+            or
+          </span>
+        </div>
+
+        <Link
+          href="/register"
+          className="w-full py-3 px-4 rounded-xl border border-white/10 bg-white/5 text-white font-medium flex items-center justify-center gap-2 hover:bg-white/10 transition-colors"
+        >
+          <User className="w-4 h-4" />
+          Create account
+        </Link>
+      </form>
+    </AuthSplitLayout>
   );
 }

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -4,9 +4,17 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAuth } from "@/lib/auth-context";
-import { Building2, Mail, Lock, User, AlertCircle, Check, Eye, EyeOff, ChevronDown } from "lucide-react";
+import { AuthSplitLayout } from "@/components/auth/AuthSplitLayout";
+import {
+  Mail,
+  Lock,
+  User,
+  AlertCircle,
+  Eye,
+  EyeOff,
+  ChevronDown,
+} from "lucide-react";
 
-// Country codes with flags
 const countryCodes = [
   { code: "+256", country: "UG", flag: "🇺🇬", name: "Uganda" },
   { code: "+254", country: "KE", flag: "🇰🇪", name: "Kenya" },
@@ -29,7 +37,7 @@ export default function RegisterPage() {
     confirmPassword: "",
     phone: "",
   });
-  const [countryCode, setCountryCode] = useState(countryCodes[0]); // Uganda default
+  const [countryCode, setCountryCode] = useState(countryCodes[0]);
   const [showCountryDropdown, setShowCountryDropdown] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -77,238 +85,211 @@ export default function RegisterPage() {
   };
 
   return (
-    <div className="min-h-screen flex bg-[var(--background)]">
-      {/* Left side - Form */}
-      <div className="flex-1 flex items-center justify-center p-8">
-        <div className="w-full max-w-md animate-fade-in">
-          <Link href="/" className="flex items-center gap-2 mb-8">
-            <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-[var(--primary-500)] to-[var(--primary-700)] flex items-center justify-center">
-              <Building2 className="w-4 h-4 text-white" />
-            </div>
-            <span className="font-semibold text-lg" style={{ fontFamily: "var(--font-outfit)" }}>
-              LandTen
-            </span>
+    <AuthSplitLayout
+      footer={
+        <>
+          By creating an account, you agree to our{" "}
+          <Link href="#" className="text-[var(--primary-400)] hover:underline">
+            Terms of Service
+          </Link>{" "}
+          and{" "}
+          <Link href="#" className="text-[var(--primary-400)] hover:underline">
+            Privacy Policy
           </Link>
-
-          <h1
-            className="text-3xl font-bold mb-2"
-            style={{ fontFamily: "var(--font-outfit)" }}
-          >
-            Create your account
-          </h1>
-          <p className="text-[var(--text-secondary)] mb-8">
-            Start managing your properties in minutes.
-          </p>
-
-          {error && (
-            <div className="flex items-center gap-2 p-3 mb-6 bg-[var(--error-light)] text-[var(--error)] rounded-lg text-sm animate-slide-down">
-              <AlertCircle className="w-4 h-4 flex-shrink-0" />
-              {error}
-            </div>
-          )}
-
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label htmlFor="name" className="label">
-                Full name
-              </label>
-              <div className="relative">
-                <User className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--text-muted)] pointer-events-none" />
-                <input
-                  id="name"
-                  name="name"
-                  type="text"
-                  value={formData.name}
-                  onChange={handleChange}
-                  className="input !pl-14"
-                  placeholder="John Doe"
-                  required
-                />
-              </div>
-            </div>
-
-            <div>
-              <label htmlFor="email" className="label">
-                Email address
-              </label>
-              <div className="relative">
-                <Mail className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--text-muted)] pointer-events-none" />
-                <input
-                  id="email"
-                  name="email"
-                  type="email"
-                  value={formData.email}
-                  onChange={handleChange}
-                  className="input !pl-14"
-                  placeholder="you@example.com"
-                  required
-                />
-              </div>
-            </div>
-
-            <div>
-              <label htmlFor="phone" className="label">
-                Phone number <span className="text-[var(--text-muted)]">(optional)</span>
-              </label>
-              <div className="relative flex">
-                {/* Country Code Dropdown */}
-                <div className="relative">
-                  <button
-                    type="button"
-                    onClick={() => setShowCountryDropdown(!showCountryDropdown)}
-                    className="flex items-center gap-1 h-full px-3 border border-r-0 border-[var(--border)] rounded-l-xl bg-[var(--surface)] hover:bg-[var(--surface-hover)] transition-colors"
-                  >
-                    <span className="text-lg">{countryCode.flag}</span>
-                    <span className="text-sm font-medium text-[var(--text-secondary)]">{countryCode.code}</span>
-                    <ChevronDown className="w-4 h-4 text-[var(--text-muted)]" />
-                  </button>
-                  {showCountryDropdown && (
-                    <div className="absolute top-full left-0 mt-1 w-56 max-h-60 overflow-y-auto bg-[var(--surface)] border border-[var(--border)] rounded-xl shadow-lg z-50">
-                      {countryCodes.map((country) => (
-                        <button
-                          key={country.code}
-                          type="button"
-                          onClick={() => {
-                            setCountryCode(country);
-                            setShowCountryDropdown(false);
-                          }}
-                          className={`w-full flex items-center gap-3 px-4 py-2.5 hover:bg-[var(--surface-hover)] transition-colors text-left ${countryCode.code === country.code ? "bg-[var(--primary-50)]" : ""
-                            }`}
-                        >
-                          <span className="text-lg">{country.flag}</span>
-                          <span className="text-sm font-medium">{country.name}</span>
-                          <span className="text-sm text-[var(--text-muted)] ml-auto">{country.code}</span>
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-                {/* Phone Input */}
-                <div className="relative flex-1">
-                  <input
-                    id="phone"
-                    name="phone"
-                    type="tel"
-                    value={formData.phone}
-                    onChange={handleChange}
-                    className="input !rounded-l-none"
-                    placeholder="712345678"
-                  />
-                </div>
-              </div>
-            </div>
-
-            <div>
-              <label htmlFor="password" className="label">
-                Password
-              </label>
-              <div className="relative">
-                <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--text-muted)] pointer-events-none" />
-                <input
-                  id="password"
-                  name="password"
-                  type={showPassword ? "text" : "password"}
-                  value={formData.password}
-                  onChange={handleChange}
-                  className="input !pl-14 !pr-12"
-                  placeholder="Create a password"
-                  required
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
-                >
-                  {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
-                </button>
-              </div>
-            </div>
-
-            <div>
-              <label htmlFor="confirmPassword" className="label">
-                Confirm password
-              </label>
-              <div className="relative">
-                <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--text-muted)] pointer-events-none" />
-                <input
-                  id="confirmPassword"
-                  name="confirmPassword"
-                  type={showConfirmPassword ? "text" : "password"}
-                  value={formData.confirmPassword}
-                  onChange={handleChange}
-                  className="input !pl-14 !pr-12"
-                  placeholder="Confirm your password"
-                  required
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                  className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
-                >
-                  {showConfirmPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
-                </button>
-              </div>
-            </div>
-
-            <button
-              type="submit"
-              disabled={isLoading}
-              className="btn btn-primary w-full py-3 mt-2"
-            >
-              {isLoading ? (
-                <>
-                  <div className="spinner" />
-                  Creating account...
-                </>
-              ) : (
-                "Create account"
-              )}
-            </button>
-          </form>
-
-          <p className="mt-6 text-center text-sm text-[var(--text-secondary)]">
-            Already have an account?{" "}
-            <Link href="/login" className="font-medium text-[var(--primary-600)] hover:text-[var(--primary-700)]">
-              Sign in
-            </Link>
-          </p>
+          .
+        </>
+      }
+    >
+      <div className="text-center">
+        <div className="w-14 h-14 mx-auto mb-5 rounded-full bg-white/5 border border-white/10 flex items-center justify-center">
+          <User className="w-6 h-6 text-[var(--primary-400)]" />
         </div>
+        <h1
+          className="text-3xl font-bold text-white mb-2"
+          style={{ fontFamily: "var(--font-outfit)" }}
+        >
+          Create your account
+        </h1>
+        <p className="text-[var(--text-secondary)] text-sm">
+          Start managing your properties in minutes.
+        </p>
       </div>
 
-      {/* Right side - Benefits */}
-      <div className="hidden lg:flex flex-1 items-center justify-center bg-gradient-to-br from-[var(--primary-500)] to-[var(--primary-800)] p-12">
-        <div className="max-w-md text-white">
-          <h2
-            className="text-3xl font-bold mb-4"
-            style={{ fontFamily: "var(--font-outfit)" }}
-          >
-            Start your free trial today
-          </h2>
-          <p className="text-[var(--primary-100)] mb-8">
-            Join thousands of landlords who use LandTen to streamline their
-            property management workflow.
-          </p>
-          <div className="space-y-4">
-            {[
-              "Track all your rental payments in one place",
-              "Set up automated payment reminders",
-              "Manage multiple properties and tenants",
-              "Get real-time notifications and reports",
-              "Free 14-day trial, no credit card required",
-            ].map((benefit) => (
-              <div
-                key={benefit}
-                className="flex items-start gap-3 text-sm text-white"
-              >
-                <div className="w-5 h-5 rounded-full bg-white/20 flex items-center justify-center flex-shrink-0 mt-0.5">
-                  <Check className="w-3 h-3" />
-                </div>
-                {benefit}
-              </div>
-            ))}
+      {error && (
+        <div className="mt-6 flex items-center gap-2 p-3 bg-[var(--error)]/10 border border-[var(--error)]/20 text-[var(--error)] rounded-xl text-sm animate-slide-down">
+          <AlertCircle className="w-4 h-4 flex-shrink-0" />
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="mt-8 space-y-5">
+        <div>
+          <label htmlFor="name" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+            Full name
+          </label>
+          <div className="relative">
+            <User className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--text-muted)] pointer-events-none" />
+            <input
+              id="name"
+              name="name"
+              type="text"
+              value={formData.name}
+              onChange={handleChange}
+              className="w-full bg-white/5 border border-white/10 rounded-xl py-3 pl-13 pr-4 text-white placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--primary-500)] focus:ring-1 focus:ring-[var(--primary-500)] transition-all"
+              placeholder="John Doe"
+              required
+              autoComplete="name"
+            />
           </div>
         </div>
-      </div>
-    </div>
+
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+            Email address
+          </label>
+          <div className="relative">
+            <Mail className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--text-muted)] pointer-events-none" />
+            <input
+              id="email"
+              name="email"
+              type="email"
+              value={formData.email}
+              onChange={handleChange}
+              className="w-full bg-white/5 border border-white/10 rounded-xl py-3 pl-13 pr-4 text-white placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--primary-500)] focus:ring-1 focus:ring-[var(--primary-500)] transition-all"
+              placeholder="you@example.com"
+              required
+              autoComplete="email"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="phone" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+            Phone number <span className="text-[var(--text-muted)]">(optional)</span>
+          </label>
+          <div className="relative flex">
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => setShowCountryDropdown(!showCountryDropdown)}
+                className="flex items-center gap-1 h-full px-3 border border-r-0 border-white/10 rounded-l-xl bg-white/5 hover:bg-white/10 transition-colors text-white"
+              >
+                <span className="text-lg">{countryCode.flag}</span>
+                <span className="text-sm font-medium text-[var(--text-secondary)]">{countryCode.code}</span>
+                <ChevronDown className="w-4 h-4 text-[var(--text-muted)]" />
+              </button>
+              {showCountryDropdown && (
+                <div className="absolute top-full left-0 mt-1 w-56 max-h-60 overflow-y-auto bg-[var(--neutral-900)] border border-white/10 rounded-xl shadow-lg z-50">
+                  {countryCodes.map((country) => (
+                    <button
+                      key={country.code}
+                      type="button"
+                      onClick={() => {
+                        setCountryCode(country);
+                        setShowCountryDropdown(false);
+                      }}
+                      className={`w-full flex items-center gap-3 px-4 py-2.5 hover:bg-white/5 transition-colors text-left ${
+                        countryCode.code === country.code ? "bg-[var(--primary-600)]/20" : ""
+                      }`}
+                    >
+                      <span className="text-lg">{country.flag}</span>
+                      <span className="text-sm font-medium text-white">{country.name}</span>
+                      <span className="text-sm text-[var(--text-muted)] ml-auto">{country.code}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+            <div className="relative flex-1">
+              <input
+                id="phone"
+                name="phone"
+                type="tel"
+                value={formData.phone}
+                onChange={handleChange}
+                className="w-full bg-white/5 border border-white/10 rounded-r-xl py-3 px-4 text-white placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--primary-500)] focus:ring-1 focus:ring-[var(--primary-500)] transition-all"
+                placeholder="712345678"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="password" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+            Password
+          </label>
+          <div className="relative">
+            <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--text-muted)] pointer-events-none" />
+            <input
+              id="password"
+              name="password"
+              type={showPassword ? "text" : "password"}
+              value={formData.password}
+              onChange={handleChange}
+              className="w-full bg-white/5 border border-white/10 rounded-xl py-3 pl-13 pr-12 text-white placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--primary-500)] focus:ring-1 focus:ring-[var(--primary-500)] transition-all"
+              placeholder="Create a password"
+              required
+              autoComplete="new-password"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword(!showPassword)}
+              className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-white transition-colors"
+            >
+              {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+            </button>
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="confirmPassword" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+            Confirm password
+          </label>
+          <div className="relative">
+            <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--text-muted)] pointer-events-none" />
+            <input
+              id="confirmPassword"
+              name="confirmPassword"
+              type={showConfirmPassword ? "text" : "password"}
+              value={formData.confirmPassword}
+              onChange={handleChange}
+              className="w-full bg-white/5 border border-white/10 rounded-xl py-3 pl-13 pr-12 text-white placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--primary-500)] focus:ring-1 focus:ring-[var(--primary-500)] transition-all"
+              placeholder="Confirm your password"
+              required
+              autoComplete="new-password"
+            />
+            <button
+              type="button"
+              onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+              className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-white transition-colors"
+            >
+              {showConfirmPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+            </button>
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full py-3 px-4 rounded-xl bg-gradient-to-r from-[var(--primary-500)] to-[var(--primary-600)] text-white font-medium flex items-center justify-center gap-2 hover:from-[var(--primary-400)] hover:to-[var(--primary-500)] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isLoading ? (
+            <>
+              <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              Creating account...
+            </>
+          ) : (
+            "Create account"
+          )}
+        </button>
+      </form>
+
+      <p className="mt-6 text-center text-sm text-[var(--text-secondary)]">
+        Already have an account?{" "}
+        <Link href="/login" className="font-medium text-[var(--primary-400)] hover:text-[var(--primary-300)] transition-colors">
+          Sign in
+        </Link>
+      </p>
+    </AuthSplitLayout>
   );
 }

--- a/frontend/src/components/auth/AuthHero.tsx
+++ b/frontend/src/components/auth/AuthHero.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import {
+  BarChart3,
+  Bell,
+  Building2,
+  LayoutDashboard,
+  Users,
+} from "lucide-react";
+
+const FEATURES = [
+  {
+    icon: BarChart3,
+    title: "Rent tracking",
+    description: "Track payments, due dates, and financial performance in one place.",
+  },
+  {
+    icon: Users,
+    title: "Tenant management",
+    description: "Store tenant details, leases, and communication history securely.",
+  },
+  {
+    icon: Building2,
+    title: "Multiple properties",
+    description: "Manage all your properties and units from a single, powerful dashboard.",
+  },
+  {
+    icon: Bell,
+    title: "Real-time notifications",
+    description: "Stay updated with instant alerts on payments and important events.",
+  },
+];
+
+const TRUST_MARKS = [
+  "Urban Nest",
+  "Pinecrest",
+  "Summit",
+  "Horizon",
+];
+
+export function AuthHero() {
+  return (
+    <div className="hidden lg:flex flex-1 relative overflow-hidden bg-gradient-to-br from-[var(--primary-500)] via-[var(--primary-600)] to-[var(--primary-800)]">
+      {/* Property photo background with warm overlay */}
+      <div
+        className="absolute inset-0 bg-cover bg-center"
+        style={{ backgroundImage: "url('/images/property.png')" }}
+      />
+      <div className="absolute inset-0 bg-gradient-to-br from-[var(--primary-500)]/92 via-[var(--primary-600)]/88 to-[var(--primary-800)]/90" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(255,255,255,0.10),transparent_45%)]" />
+
+      {/* Content */}
+      <div className="relative z-10 flex flex-col justify-between h-full p-12 xl:p-16">
+        <div className="max-w-lg">
+          <h2
+            className="text-4xl xl:text-5xl font-bold text-white leading-tight mb-4"
+            style={{ fontFamily: "var(--font-outfit)" }}
+          >
+            Manage your properties with ease
+          </h2>
+          <p className="text-[var(--primary-100)] text-base xl:text-lg leading-relaxed">
+            LandTen helps you stay organized, collect rent on time, and build better
+            relationships with your tenants.
+          </p>
+        </div>
+
+        {/* Feature list */}
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-4 max-w-xl">
+          {FEATURES.map(({ icon: Icon, title, description }) => (
+            <div key={title} className="flex gap-4">
+              <div className="flex-shrink-0 w-11 h-11 rounded-xl bg-white/10 backdrop-blur-sm flex items-center justify-center">
+                <Icon className="w-5 h-5 text-white" />
+              </div>
+              <div>
+                <h3 className="font-semibold text-white text-sm">{title}</h3>
+                <p className="text-[var(--primary-100)] text-xs leading-relaxed mt-0.5">
+                  {description}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Dashboard mockup */}
+        <div className="relative max-w-xl w-full hidden xl:block">
+          <div className="rounded-2xl border border-white/15 bg-white/10 backdrop-blur-md shadow-2xl overflow-hidden">
+            <div className="flex h-64">
+              {/* Sidebar */}
+              <div className="w-40 bg-[var(--neutral-900)]/80 p-4 flex flex-col gap-3">
+                <div className="flex items-center gap-2 text-white font-semibold text-xs mb-2">
+                  <div className="w-5 h-5 rounded bg-gradient-to-br from-[var(--primary-500)] to-[var(--primary-700)] flex items-center justify-center">
+                    <Building2 className="w-3 h-3 text-white" />
+                  </div>
+                  LandTen
+                </div>
+                {["Overview", "Properties", "Tenants", "Payments", "Maintenance"].map(
+                  (item, i) => (
+                    <div
+                      key={item}
+                      className={`flex items-center gap-2 px-2 py-1.5 rounded-lg text-xs ${
+                        i === 0
+                          ? "bg-[var(--primary-600)]/50 text-white"
+                          : "text-[var(--text-muted)]"
+                      }`}
+                    >
+                      <div className="w-3.5 h-3.5 rounded bg-white/10" />
+                      {item}
+                    </div>
+                  )
+                )}
+              </div>
+
+              {/* Main panel */}
+              <div className="flex-1 bg-[var(--surface)]/95 p-5">
+                <h4 className="text-[var(--text-primary)] font-semibold text-sm mb-4">
+                  Overview
+                </h4>
+                <div className="grid grid-cols-3 gap-3 mb-4">
+                  {[
+                    { label: "Total Properties", value: "24" },
+                    { label: "Total Tenants", value: "156" },
+                    { label: "Monthly Revenue", value: "$45,320" },
+                  ].map(({ label, value }) => (
+                    <div
+                      key={label}
+                      className="rounded-xl bg-[var(--surface-inset)] p-3"
+                    >
+                      <p className="text-[var(--text-muted)] text-[10px] uppercase tracking-wide">
+                        {label}
+                      </p>
+                      <p className="text-[var(--text-primary)] font-bold text-lg mt-1">
+                        {value}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+                <div className="flex gap-4">
+                  <div className="flex-1 rounded-xl bg-[var(--surface-inset)] p-3 h-20">
+                    <div className="flex items-center gap-2 mb-2">
+                      <LayoutDashboard className="w-3.5 h-3.5 text-[var(--primary-500)]" />
+                      <span className="text-[var(--text-primary)] text-xs font-medium">
+                        Recent Payments
+                      </span>
+                    </div>
+                    <div className="space-y-1.5">
+                      {[1, 2].map((i) => (
+                        <div key={i} className="flex items-center justify-between">
+                          <div className="w-16 h-1.5 rounded-full bg-[var(--border)]" />
+                          <div className="w-8 h-1.5 rounded-full bg-[var(--success)]" />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="w-28 rounded-xl bg-[var(--surface-inset)] p-3 h-20 flex flex-col items-center justify-center">
+                    <div className="w-12 h-12 rounded-full border-4 border-[var(--primary-500)] flex items-center justify-center">
+                      <span className="text-[var(--text-primary)] text-[10px] font-bold">
+                        80%
+                      </span>
+                    </div>
+                    <span className="text-[var(--text-muted)] text-[10px] mt-1">
+                      Collected
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Trust badges */}
+        <div className="max-w-xl">
+          <p className="text-[var(--primary-100)] text-xs mb-4">
+            Trusted by property managers worldwide
+          </p>
+          <div className="flex items-center gap-6 opacity-80">
+            {TRUST_MARKS.map((name) => (
+              <div key={name} className="flex items-center gap-1.5 text-white/90">
+                <Building2 className="w-4 h-4" />
+                <span className="text-xs font-medium tracking-wide">{name}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/auth/AuthSplitLayout.tsx
+++ b/frontend/src/components/auth/AuthSplitLayout.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import Link from "next/link";
+import { Building2 } from "lucide-react";
+import { AuthHero } from "./AuthHero";
+
+interface AuthSplitLayoutProps {
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+export function AuthSplitLayout({ children, footer }: AuthSplitLayoutProps) {
+  return (
+    <div className="min-h-screen flex bg-[var(--neutral-950)]">
+      {/* Left side — dark form panel */}
+      <div className="relative flex-1 flex flex-col min-h-screen">
+        <Link
+          href="/"
+          className="absolute top-6 left-6 sm:top-8 sm:left-8 flex items-center gap-2 z-10"
+        >
+          <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-[var(--primary-500)] to-[var(--primary-700)] flex items-center justify-center">
+            <Building2 className="w-4 h-4 text-white" />
+          </div>
+          <span
+            className="font-semibold text-lg text-white"
+            style={{ fontFamily: "var(--font-outfit)" }}
+          >
+            LandTen
+          </span>
+        </Link>
+
+        <div className="flex-1 flex items-center justify-center p-6 sm:p-8">
+          <div className="w-full max-w-md animate-fade-in">{children}</div>
+        </div>
+
+        {footer && (
+          <div className="px-6 pb-6 sm:px-8 sm:pb-8 text-center text-xs text-[var(--text-muted)]">
+            {footer}
+          </div>
+        )}
+      </div>
+
+      {/* Right side — hero panel */}
+      <AuthHero />
+    </div>
+  );
+}


### PR DESCRIPTION
1. Extracted AuthSplitLayout and AuthHero components for consistent split-screen auth UI based on provided visual reference.
2. Refactored login and register pages to use the new layout.
3. Added the property background image to the AuthHero right-side panel with a custom gradient mesh and SVG silhouettes.
4. Fixed a bug where the 'Add Room' dropdown was hidden behind the empty-state container card by removing \overflow: hidden\ from the global \.card\ CSS class and adjusting stacking contexts.