### PR TITLE
fix(tenant): prevent currency code overlap in add tenant modal

### DIFF
--- a/frontend/src/components/modals/AddTenantModal.tsx
+++ b/frontend/src/components/modals/AddTenantModal.tsx
@@ -247,7 +247,7 @@ export function AddTenantModal({
                           amount: parseFloat(e.target.value) || 0,
                         }))
                       }
-                      className="input pl-12"
+                      className="input !pl-16"
                       min="0"
                       required
                     />


### PR DESCRIPTION
Increased the left padding on the rent amount input field (\!pl-16\) in the Add Tenant Modal (Step 2) so that 3-letter currency codes like 'UGX' do not overlap with the typed numbers.