### PR TITLE
fix(demo): resolve critical path inconsistencies and update defaults

### DIFF
--- a/frontend/src/app/dashboard/properties/[id]/page.tsx
+++ b/frontend/src/app/dashboard/properties/[id]/page.tsx
@@ -288,10 +288,15 @@ export default function PropertyDetailPage() {
           <p className="empty-state-description">
             Add rooms to this property to start managing tenants.
           </p>
-          <button onClick={() => setShowAddRoom(true)} className="btn btn-primary">
-            <Plus className="w-4 h-4" />
-            Add Room
-          </button>
+          <div className="flex flex-col items-center gap-3 mt-2">
+            <button onClick={() => setShowBulkModal(true)} className="btn btn-primary">
+              <Layers className="w-4 h-4" />
+              Create rooms in bulk
+            </button>
+            <button onClick={() => setShowAddRoom(true)} className="text-sm text-[var(--primary-600)] hover:text-[var(--primary-700)] font-medium">
+              Add one room instead
+            </button>
+          </div>
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 animate-slide-up stagger-2">
@@ -1280,8 +1285,7 @@ function BulkRoomModal({
                 <div>
                   <p className="font-medium">Some rooms have no price set</p>
                   <p className="text-xs mt-0.5">
-                    Rooms {gaps.map(([f, t]) => (f === t ? f : `${f}-${t}`)).join(", ")}{" "}
-                    will use the default price (first range).
+                    Rooms {gaps.map(([f, t]) => (f === t ? f : `${f}-${t}`)).join(", ")} have no price assigned and will not be created unless you assign a price.
                   </p>
                 </div>
               </div>

--- a/frontend/src/app/dashboard/properties/page.tsx
+++ b/frontend/src/app/dashboard/properties/page.tsx
@@ -38,10 +38,13 @@ export default function PropertiesPage() {
     }
   };
 
-  const formatCurrency = (amount: number) => {
+  const formatCurrency = (amount: number, currencyCode: string = "UGX") => {
+    if (["UGX", "KES", "TZS", "RWF"].includes(currencyCode)) {
+      return `${currencyCode} ${amount.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+    }
     return new Intl.NumberFormat("en-US", {
       style: "currency",
-      currency: "USD",
+      currency: currencyCode,
       minimumFractionDigits: 0,
     }).format(amount);
   };

--- a/frontend/src/components/modals/AddTenantModal.tsx
+++ b/frontend/src/components/modals/AddTenantModal.tsx
@@ -29,7 +29,7 @@ export function AddTenantModal({
   });
   const [scheduleData, setScheduleData] = useState({
     amount: 0,
-    frequency: "MONTHLY",
+    frequency: "BI_MONTHLY",
     due_day: 1,
     window_days: 5,
     start_date: new Date().toISOString().split("T")[0],

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -468,7 +468,7 @@ class ApiClient {
     data: { payment_reference: string; notes?: string }
   ) {
     return this.request<Payment>(`/payments/${id}/mark-paid`, {
-      method: "POST",
+      method: "PUT",
       body: JSON.stringify(data),
     });
   }


### PR DESCRIPTION
Addresses feedback regarding demo-breaking inconsistencies to ensure a smooth core landlord journey:

1. **Mark Paid API Mismatch**: Fixed frontend \markPaymentPaid()\ to use \PUT\ to match the backend route instead of \POST\.
2. **Bulk Room Gap Warning**: Changed the warning message in the bulk room modal. The backend skips rooms without a price, so the warning now accurately states they will not be created unless a price is assigned.
3. **Currency Default**: Removed the \USD\ default formatting on the properties cards and set the default fallback to \UGX\.
4. **Tenant Payment Schedule**: Updated the default payment schedule in the Add Tenant modal to \BI_MONTHLY\ (due day 1, 5 days window) to match the real-world requirement.
5. **Empty State Priority**: Updated the empty state on the Property Details page to prioritize 'Create rooms in bulk' over a single room addition when there are no rooms.