### PR TITLE
fix: consolidate demo-ready landlord flow

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -110,7 +110,6 @@ async def lifespan(app: FastAPI):
     print("[Scheduler] Background scheduler stopped")
 
 
-from fastapi.staticfiles import StaticFiles
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 import os
@@ -122,6 +121,10 @@ os.makedirs("uploads/receipts", exist_ok=True)
 os.makedirs("uploads/disputes", exist_ok=True)
 os.makedirs("uploads/maintenance", exist_ok=True)
 os.makedirs("uploads/leases", exist_ok=True)
+
+# Upload subdirectories are intentionally NOT mounted as static files.
+# Receipts, leases, maintenance attachments, and dispute files must be
+# served through authenticated API endpoints only.
 
 # Create FastAPI app
 app = FastAPI(
@@ -159,20 +162,6 @@ app.include_router(maintenance.router, prefix="/api")
 app.include_router(notifications.router, prefix="/api")
 app.include_router(analytics.router, prefix="/api")
 app.include_router(leases.router, prefix="/api")
-
-
-@app.get("/uploads/maintenance/{filename:path}")
-async def block_public_maintenance_uploads(filename: str):
-    """Maintenance attachments must be served via authenticated routes."""
-    _ = filename
-    raise HTTPException(
-        status_code=status.HTTP_404_NOT_FOUND,
-        detail="Maintenance attachment not found",
-    )
-
-
-# Mount static files for uploads
-app.mount("/uploads", StaticFiles(directory="uploads"), name="uploads")
 
 
 @app.get("/")

--- a/backend/app/models/payment_schedule.py
+++ b/backend/app/models/payment_schedule.py
@@ -24,7 +24,7 @@ class PaymentSchedule(SQLModel, table=True):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True)
     tenant_id: str = Field(foreign_key="tenants.id", unique=True, index=True)
     amount: float  # Amount due each period
-    frequency: PaymentFrequency = Field(default=PaymentFrequency.MONTHLY)
+    frequency: PaymentFrequency = Field(default=PaymentFrequency.BI_MONTHLY)
     due_day: int = Field(default=1, ge=1, le=28)  # Day of month payment is due
     window_days: int = Field(
         default=5, ge=1

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -5,13 +5,14 @@ Provides aggregated statistics across properties, payments, and vacancies.
 
 from fastapi import APIRouter, Depends
 from sqlmodel import Session, select
-from datetime import date
+from datetime import date, datetime, timezone
 from dateutil.relativedelta import relativedelta
 from typing import List, Dict
 
 from app.core.database import get_session
 from app.core.security import get_current_landlord
 from app.core.currency import convert_currency
+from app.routers.payments import update_payment_status
 from app.models.landlord import Landlord
 from app.models.property import Property
 from app.models.room import Room
@@ -248,6 +249,16 @@ async def get_dashboard_analytics(
 
     # Get current date info
     today = date.today()
+
+    # Refresh payment statuses before aggregating analytics so dashboards
+    # reflect the current date instead of stale scheduled values.
+    for payment in payments:
+        new_status = update_payment_status(payment, today)
+        if new_status != payment.status:
+            payment.status = new_status
+            payment.updated_at = datetime.now(timezone.utc)
+            session.add(payment)
+    session.commit()
     current_year = today.year
     current_month = today.month
 

--- a/backend/app/routers/payments.py
+++ b/backend/app/routers/payments.py
@@ -7,6 +7,7 @@ from dateutil.relativedelta import relativedelta
 import mimetypes
 import logging
 
+from app.core.currency import convert_currency
 from app.core.database import get_session
 from app.core.security import (
     decode_token,
@@ -430,6 +431,15 @@ async def get_payment_summary(
     if not tenant_ids:
         return PaymentSummary()
 
+    # Get tenants and rooms so we can convert mixed-currency payments into the
+    # landlord's primary currency before summing.
+    tenants = session.exec(select(Tenant).where(Tenant.id.in_(tenant_ids))).all()
+    tenant_room_map = {t.id: t.room_id for t in tenants}
+    room_ids = [rid for rid in tenant_room_map.values() if rid]
+    rooms = session.exec(select(Room).where(Room.id.in_(room_ids))).all() if room_ids else []
+    room_currency_map = {r.id: r.currency for r in rooms}
+    target_currency = current_landlord.primary_currency or "UGX"
+
     # Get all payments for these tenants
     payments = session.exec(
         select(Payment).where(Payment.tenant_id.in_(tenant_ids))
@@ -453,7 +463,9 @@ async def get_payment_summary(
             payment.updated_at = datetime.now(timezone.utc)
             session.add(payment)
 
-        amount = payment.amount_due
+        room_id = tenant_room_map.get(payment.tenant_id)
+        payment_currency = room_currency_map.get(room_id, "UGX") if room_id else "UGX"
+        amount = convert_currency(payment.amount_due, payment_currency, target_currency)
 
         if payment.status == PaymentStatus.UPCOMING:
             upcoming += 1

--- a/backend/app/routers/payments.py
+++ b/backend/app/routers/payments.py
@@ -321,6 +321,8 @@ async def list_payments(
     status_filter: Optional[PaymentStatus] = Query(None, alias="status"),
     property_id: Optional[str] = None,
     tenant_id: Optional[str] = None,
+    start_date: Optional[date] = Query(None, description="Filter payments from this due date (inclusive)"),
+    end_date: Optional[date] = Query(None, description="Filter payments up to this due date (inclusive)"),
     current_landlord: Landlord = Depends(get_current_landlord),
     session: Session = Depends(get_session),
 ):
@@ -358,6 +360,11 @@ async def list_payments(
             ).all()
         ]
         query = query.where(Payment.tenant_id.in_(property_tenant_ids))
+
+    if start_date:
+        query = query.where(Payment.due_date >= start_date)
+    if end_date:
+        query = query.where(Payment.due_date <= end_date)
 
     payments = session.exec(query.order_by(Payment.due_date.desc())).all()
 

--- a/backend/app/routers/payments.py
+++ b/backend/app/routers/payments.py
@@ -401,20 +401,30 @@ async def get_payment_summary(
     today = date.today()
     first_of_month = date(today.year, today.month, 1)
 
+    # If a property filter is supplied, verify it belongs to the landlord first.
+    if property_id:
+        property = session.get(Property, property_id)
+        if not property or property.landlord_id != current_landlord.id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Property not found"
+            )
+
     tenant_ids = get_landlord_tenant_ids(current_landlord.id, session)
     if not tenant_ids:
         return PaymentSummary()
 
-    # Filter by property if specified
+    # Filter by property if specified.
     if property_id:
         rooms = session.exec(select(Room).where(Room.property_id == property_id)).all()
         room_ids = [r.id for r in rooms]
-        tenant_ids = [
+        property_tenant_ids = {
             t.id
             for t in session.exec(
                 select(Tenant).where(Tenant.room_id.in_(room_ids))
             ).all()
-        ]
+        }
+        # Intersect with landlord's tenant scope.
+        tenant_ids = list(set(tenant_ids) & property_tenant_ids)
 
     if not tenant_ids:
         return PaymentSummary()
@@ -479,6 +489,7 @@ async def get_payment_summary(
 @router.get("/upcoming", response_model=PaymentListResponse)
 async def get_upcoming_payments(
     days: int = Query(30, ge=1, le=90),
+    property_id: Optional[str] = Query(None, description="Filter by property ID"),
     current_landlord: Landlord = Depends(get_current_landlord),
     session: Session = Depends(get_session),
 ):
@@ -489,6 +500,26 @@ async def get_upcoming_payments(
     end_date = today + relativedelta(days=days)
 
     tenant_ids = get_landlord_tenant_ids(current_landlord.id, session)
+    if not tenant_ids:
+        return PaymentListResponse(payments=[], total=0)
+
+    # Apply property filter, verifying the property belongs to the landlord.
+    if property_id:
+        property = session.get(Property, property_id)
+        if not property or property.landlord_id != current_landlord.id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Property not found"
+            )
+        rooms = session.exec(select(Room).where(Room.property_id == property_id)).all()
+        room_ids = [r.id for r in rooms]
+        property_tenant_ids = {
+            t.id
+            for t in session.exec(
+                select(Tenant).where(Tenant.room_id.in_(room_ids))
+            ).all()
+        }
+        tenant_ids = list(set(tenant_ids) & property_tenant_ids)
+
     if not tenant_ids:
         return PaymentListResponse(payments=[], total=0)
 
@@ -649,6 +680,7 @@ async def export_payments(
 
 @router.get("/overdue", response_model=PaymentListResponse)
 async def get_overdue_payments(
+    property_id: Optional[str] = Query(None, description="Filter by property ID"),
     current_landlord: Landlord = Depends(get_current_landlord),
     session: Session = Depends(get_session),
 ):
@@ -661,6 +693,26 @@ async def get_overdue_payments(
     if not tenant_ids:
         return PaymentListResponse(payments=[], total=0)
 
+    # Apply property filter, verifying the property belongs to the landlord.
+    if property_id:
+        property = session.get(Property, property_id)
+        if not property or property.landlord_id != current_landlord.id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Property not found"
+            )
+        rooms = session.exec(select(Room).where(Room.property_id == property_id)).all()
+        room_ids = [r.id for r in rooms]
+        property_tenant_ids = {
+            t.id
+            for t in session.exec(
+                select(Tenant).where(Tenant.room_id.in_(room_ids))
+            ).all()
+        }
+        tenant_ids = list(set(tenant_ids) & property_tenant_ids)
+
+    if not tenant_ids:
+        return PaymentListResponse(payments=[], total=0)
+
     # Get payments past their window
     payments = session.exec(
         select(Payment)
@@ -668,7 +720,12 @@ async def get_overdue_payments(
             Payment.tenant_id.in_(tenant_ids),
             Payment.window_end_date < today,
             Payment.status.notin_(
-                [PaymentStatus.ON_TIME, PaymentStatus.LATE, PaymentStatus.WAIVED]
+                [
+                    PaymentStatus.ON_TIME,
+                    PaymentStatus.LATE,
+                    PaymentStatus.WAIVED,
+                    PaymentStatus.VERIFYING,
+                ]
             ),
         )
         .order_by(Payment.due_date)

--- a/backend/app/routers/payments.py
+++ b/backend/app/routers/payments.py
@@ -97,7 +97,8 @@ def _parse_payment_status_filters(raw_statuses: str) -> list[PaymentStatus]:
 
 def _resolve_receipt_file_path(receipt_url: str) -> str:
     """Resolve a receipt_url to a safe local file path."""
-    # We only support serving receipts from our mounted uploads path.
+    # Receipts are stored under uploads/receipts and served only through
+    # authenticated API endpoints (never mounted publicly).
     if not receipt_url or not receipt_url.startswith("/uploads/receipts/"):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Receipt not found"
@@ -188,8 +189,8 @@ def calculate_period_dates(
     # Due date is at the start of the period
     due_date = period_start
 
-    # Window end date
-    window_end_date = due_date + relativedelta(days=schedule.window_days)
+    # Window end date (inclusive: e.g. due_day=1 with window_days=5 -> 1st-5th)
+    window_end_date = due_date + relativedelta(days=schedule.window_days - 1)
 
     return period_start, period_end, due_date, window_end_date
 
@@ -668,7 +669,12 @@ async def get_overdue_payments(
             Payment.tenant_id.in_(tenant_ids),
             Payment.window_end_date < today,
             Payment.status.notin_(
-                [PaymentStatus.ON_TIME, PaymentStatus.LATE, PaymentStatus.WAIVED]
+                [
+                    PaymentStatus.ON_TIME,
+                    PaymentStatus.LATE,
+                    PaymentStatus.WAIVED,
+                    PaymentStatus.VERIFYING,
+                ]
             ),
         )
         .order_by(Payment.due_date)
@@ -917,8 +923,8 @@ async def create_manual_payment(
             status_code=status.HTTP_404_NOT_FOUND, detail="Tenant not found"
         )
 
-    # Calculate window end (use default 5 days)
-    window_end_date = payment_data.due_date + relativedelta(days=5)
+    # Calculate window end (use default 5-day inclusive window)
+    window_end_date = payment_data.due_date + relativedelta(days=4)
 
     payment = Payment(
         tenant_id=payment_data.tenant_id,
@@ -1005,9 +1011,8 @@ async def upload_payment_receipt(
             detail=f"Could not save file: {str(e)}",
         )
 
-    # Update payment record
-    # Construct URL relative to base URL (client handles full URL construction)
-    # We mounted "uploads" in main.py so this is accessible via /uploads/...
+    # Update payment record.  The URL is a storage identifier only; receipts
+    # are served through the authenticated /payments/{id}/receipt endpoint.
     payment.receipt_url = f"/uploads/receipts/{filename}"
     payment.status = PaymentStatus.VERIFYING
     payment.updated_at = datetime.now(timezone.utc)

--- a/backend/app/routers/payments.py
+++ b/backend/app/routers/payments.py
@@ -422,9 +422,10 @@ async def get_payment_summary(
     pending = 0
     overdue = 0
     paid_count = 0
-    total_expected = 0
-    total_received = 0
-    total_outstanding = 0
+    total_expected = 0.0
+    total_received = 0.0
+    total_outstanding = 0.0
+    total_overdue = 0.0
 
     for payment in payments:
         # Update status
@@ -434,23 +435,25 @@ async def get_payment_summary(
             payment.updated_at = datetime.now(timezone.utc)
             session.add(payment)
 
+        amount = payment.amount_due
+
         if payment.status == PaymentStatus.UPCOMING:
             upcoming += 1
-            total_expected += 1
-            total_outstanding += 1
+            total_expected += amount
+            total_outstanding += amount
         elif payment.status == PaymentStatus.PENDING:
             pending += 1
-            total_expected += 1
-            total_outstanding += 1
+            total_expected += amount
+            total_outstanding += amount
         elif payment.status == PaymentStatus.OVERDUE:
             overdue += 1
-            total_expected += 1
-            total_outstanding += 1
+            total_expected += amount
+            total_outstanding += amount
+            total_overdue += amount
         elif payment.status in [PaymentStatus.ON_TIME, PaymentStatus.LATE]:
             paid_count += 1
-            total_received += 1
-            if payment.status == PaymentStatus.LATE:
-                total_expected += 1
+            total_received += amount
+            total_expected += amount
 
     session.commit()
 
@@ -458,7 +461,7 @@ async def get_payment_summary(
         total_expected=total_expected,
         total_received=total_received,
         total_outstanding=total_outstanding,
-        total_overdue=overdue,
+        total_overdue=total_overdue,
         upcoming_count=upcoming,
         pending_count=pending,
         overdue_count=overdue,

--- a/backend/app/routers/properties.py
+++ b/backend/app/routers/properties.py
@@ -74,6 +74,7 @@ async def create_property(
         name=property_data.name,
         address=property_data.address,
         description=property_data.description,
+        grace_period_days=property_data.grace_period_days,
     )
     session.add(property)
     session.commit()
@@ -138,6 +139,8 @@ async def update_property(
         property.address = update_data.address
     if update_data.description is not None:
         property.description = update_data.description
+    if update_data.grace_period_days is not None:
+        property.grace_period_days = update_data.grace_period_days
 
     property.updated_at = datetime.now(timezone.utc)
     session.add(property)

--- a/backend/app/routers/rooms.py
+++ b/backend/app/routers/rooms.py
@@ -288,6 +288,14 @@ async def create_rooms_bulk(
         else:
             warnings.append(f"Rooms {gap_start}-{gap_end} have no price assigned.")
 
+    # Detect existing room names to avoid duplicates
+    existing_room_names = {
+        room.name
+        for room in session.exec(
+            select(Room).where(Room.property_id == property_id)
+        ).all()
+    }
+
     # Create rooms
     created_rooms = []
     for num in range(bulk_data.from_number, bulk_data.to_number + 1):
@@ -305,6 +313,11 @@ async def create_rooms_bulk(
 
         room_name = f"{bulk_data.prefix}{num_str}"
 
+        # Skip duplicates
+        if room_name in existing_room_names:
+            warnings.append(f"Room '{room_name}' already exists and was skipped.")
+            continue
+
         room = Room(
             property_id=property_id,
             name=room_name,
@@ -313,6 +326,7 @@ async def create_rooms_bulk(
         )
         session.add(room)
         created_rooms.append(room)
+        existing_room_names.add(room_name)
 
     session.commit()
 

--- a/backend/app/routers/tenants.py
+++ b/backend/app/routers/tenants.py
@@ -159,7 +159,7 @@ async def create_tenant(
     By default (auto_create_schedule=True), automatically:
     1. Creates a payment schedule using the room's rent amount
     2. Uses the property's grace_period_days for the payment window
-    3. Creates a prorated payment if move-in is after the 5th of the month
+    3. Creates a prorated payment only if the first scheduled period is deferred
     4. Generates the first scheduled payment
 
     Set auto_create_schedule=False to skip automatic schedule creation.

--- a/backend/app/routers/tenants.py
+++ b/backend/app/routers/tenants.py
@@ -229,8 +229,14 @@ async def create_tenant(
         session.commit()
         session.refresh(schedule)
 
-        # Create prorated payment if move-in is after the 5th of the month
-        if tenant_data.move_in_date.day > 5:
+        # Create a prorated payment only when the first scheduled period is
+        # deferred to a later month. This avoids double-charging when the
+        # scheduled payment already covers the move-in month.
+        schedule_deferred = (
+            schedule_start.year != tenant_data.move_in_date.year
+            or schedule_start.month != tenant_data.move_in_date.month
+        )
+        if schedule_deferred:
             prorated_payment = create_prorated_payment(
                 tenant_id=tenant.id,
                 monthly_rent=rent_amount,

--- a/backend/app/routers/tenants.py
+++ b/backend/app/routers/tenants.py
@@ -486,6 +486,12 @@ async def create_tenant_schedule(
     session.commit()
     session.refresh(schedule)
 
+    # Generate the first scheduled payment immediately so the payment appears
+    # in the landlord dashboard without waiting for a background job.
+    generate_payment_for_schedule(schedule, session, force=True)
+    session.commit()
+    session.refresh(schedule)
+
     return PaymentScheduleResponse.model_validate(schedule)
 
 

--- a/backend/app/routers/tenants.py
+++ b/backend/app/routers/tenants.py
@@ -1,8 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session, select
 from typing import Optional
-from datetime import datetime, date, timezone
-from dateutil.relativedelta import relativedelta
+from datetime import datetime, timezone
 
 from app.core.database import get_session
 from app.core.security import (
@@ -36,6 +35,7 @@ from app.schemas.payment import PaymentResponse
 from app.services.payment_service import (
     create_prorated_payment,
     generate_payment_for_schedule,
+    normalize_schedule_start,
 )
 
 router = APIRouter(prefix="/tenants", tags=["Tenants"])
@@ -209,16 +209,12 @@ async def create_tenant(
         # Determine window days (explicit, from property, or default 5)
         window_days = tenant_data.payment_window_days or property.grace_period_days
 
-        # Calculate schedule start date
-        # If move-in is on 1st-5th, schedule starts this month
-        # If move-in is after 5th, schedule starts next month (1st)
-        move_in = tenant_data.move_in_date
-        if move_in.day <= 5:
-            schedule_start = date(move_in.year, move_in.month, 1)
-        else:
-            # Start from 1st of next month
-            next_month = move_in + relativedelta(months=1)
-            schedule_start = date(next_month.year, next_month.month, 1)
+        # Align schedule start so the first payment window is not already closed.
+        schedule_start = normalize_schedule_start(
+            tenant_data.move_in_date,
+            tenant_data.payment_due_day or 1,
+            window_days,
+        )
 
         # Create the payment schedule
         schedule = PaymentSchedule(
@@ -233,12 +229,12 @@ async def create_tenant(
         session.commit()
         session.refresh(schedule)
 
-        # Create prorated payment if move-in is after 5th
-        if move_in.day > 5:
+        # Create prorated payment if move-in is after the 5th of the month
+        if tenant_data.move_in_date.day > 5:
             prorated_payment = create_prorated_payment(
                 tenant_id=tenant.id,
                 monthly_rent=rent_amount,
-                move_in_date=move_in,
+                move_in_date=tenant_data.move_in_date,
                 session=session,
             )
 
@@ -474,13 +470,21 @@ async def create_tenant_schedule(
             detail="Tenant already has an active payment schedule",
         )
 
+    # Align the schedule start so the first payment window is not already
+    # closed when the landlord creates the schedule mid-month.
+    schedule_start = normalize_schedule_start(
+        schedule_data.start_date,
+        schedule_data.due_day,
+        schedule_data.window_days,
+    )
+
     schedule = PaymentSchedule(
         tenant_id=tenant_id,
         amount=schedule_data.amount,
         frequency=schedule_data.frequency,
         due_day=schedule_data.due_day,
         window_days=schedule_data.window_days,
-        start_date=schedule_data.start_date,
+        start_date=schedule_start,
     )
     session.add(schedule)
     session.commit()

--- a/backend/app/routers/tenants.py
+++ b/backend/app/routers/tenants.py
@@ -30,6 +30,9 @@ from app.schemas.payment_schedule import (
     PaymentScheduleUpdate,
     PaymentScheduleResponse,
 )
+from app.schemas.room import RoomResponse
+from app.schemas.property import PropertyResponse
+from app.schemas.payment import PaymentResponse
 from app.services.payment_service import (
     create_prorated_payment,
     generate_payment_for_schedule,
@@ -130,6 +133,12 @@ async def list_tenants(
                 has_portal_access=tenant.password_hash is not None,
                 pending_payments=len(pending_count),
                 overdue_payments=len(overdue_count),
+                room=RoomResponse.model_validate(room) if room else None,
+                property=PropertyResponse.model_validate(property) if property else None,
+                payment_schedule=PaymentScheduleResponse.model_validate(schedule)
+                if schedule
+                else None,
+                payments=[],
             )
         )
 
@@ -242,13 +251,21 @@ async def create_tenant(
     return TenantWithDetails(
         **tenant.model_dump(),
         room_name=room.name,
-        property_id=property.id,
         property_name=property.name,
+        property_id=property.id,
         rent_amount=room.rent_amount,
         has_payment_schedule=schedule is not None,
         has_portal_access=tenant.password_hash is not None,
         pending_payments=1 if prorated_payment else 0,
         overdue_payments=0,
+        room=RoomResponse.model_validate(room),
+        property=PropertyResponse.model_validate(property),
+        payment_schedule=PaymentScheduleResponse.model_validate(schedule)
+        if schedule
+        else None,
+        payments=[PaymentResponse.model_validate(prorated_payment)]
+        if prorated_payment
+        else [],
     )
 
 
@@ -276,20 +293,17 @@ async def get_tenant(
         )
     ).first()
 
+    # Get payments for this tenant
+    payments = session.exec(
+        select(Payment).where(Payment.tenant_id == tenant.id)
+    ).all()
+
     # Count pending/overdue payments
     pending_count = len(
-        session.exec(
-            select(Payment).where(
-                Payment.tenant_id == tenant.id, Payment.status == PaymentStatus.PENDING
-            )
-        ).all()
+        [p for p in payments if p.status == PaymentStatus.PENDING]
     )
     overdue_count = len(
-        session.exec(
-            select(Payment).where(
-                Payment.tenant_id == tenant.id, Payment.status == PaymentStatus.OVERDUE
-            )
-        ).all()
+        [p for p in payments if p.status == PaymentStatus.OVERDUE]
     )
 
     return TenantWithDetails(
@@ -302,6 +316,12 @@ async def get_tenant(
         has_portal_access=tenant.password_hash is not None,
         pending_payments=pending_count,
         overdue_payments=overdue_count,
+        room=RoomResponse.model_validate(room),
+        property=PropertyResponse.model_validate(property),
+        payment_schedule=PaymentScheduleResponse.model_validate(schedule)
+        if schedule
+        else None,
+        payments=[PaymentResponse.model_validate(p) for p in payments],
     )
 
 

--- a/backend/app/routers/tenants.py
+++ b/backend/app/routers/tenants.py
@@ -224,7 +224,7 @@ async def create_tenant(
         schedule = PaymentSchedule(
             tenant_id=tenant.id,
             amount=rent_amount,
-            frequency=tenant_data.payment_frequency or PaymentFrequency.MONTHLY,
+            frequency=tenant_data.payment_frequency or PaymentFrequency.BI_MONTHLY,
             due_day=tenant_data.payment_due_day or 1,
             window_days=window_days,
             start_date=schedule_start,

--- a/backend/app/schemas/payment.py
+++ b/backend/app/schemas/payment.py
@@ -90,10 +90,10 @@ class PaymentListResponse(BaseModel):
 class PaymentSummary(BaseModel):
     """Summary statistics for dashboard"""
 
-    total_expected: int = 0
-    total_received: int = 0
-    total_outstanding: int = 0
-    total_overdue: int = 0
+    total_expected: float = 0
+    total_received: float = 0
+    total_outstanding: float = 0
+    total_overdue: float = 0
     upcoming_count: int = 0
     pending_count: int = 0
     overdue_count: int = 0

--- a/backend/app/schemas/payment_schedule.py
+++ b/backend/app/schemas/payment_schedule.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Optional
 from datetime import datetime, date
 from app.models.payment_schedule import PaymentFrequency
@@ -6,10 +6,10 @@ from app.models.payment_schedule import PaymentFrequency
 
 # Request schemas
 class PaymentScheduleCreate(BaseModel):
-    amount: float
-    frequency: PaymentFrequency = PaymentFrequency.MONTHLY
-    due_day: int = 1  # 1-28
-    window_days: int = 5
+    amount: float = Field(..., gt=0)
+    frequency: PaymentFrequency = PaymentFrequency.BI_MONTHLY
+    due_day: int = Field(default=1, ge=1, le=28)
+    window_days: int = Field(default=5, ge=1, le=15)
     start_date: date
 
 

--- a/backend/app/schemas/payment_schedule.py
+++ b/backend/app/schemas/payment_schedule.py
@@ -14,10 +14,10 @@ class PaymentScheduleCreate(BaseModel):
 
 
 class PaymentScheduleUpdate(BaseModel):
-    amount: Optional[float] = None
+    amount: Optional[float] = Field(default=None, gt=0)
     frequency: Optional[PaymentFrequency] = None
-    due_day: Optional[int] = None
-    window_days: Optional[int] = None
+    due_day: Optional[int] = Field(default=None, ge=1, le=28)
+    window_days: Optional[int] = Field(default=None, ge=1, le=15)
     is_active: Optional[bool] = None
 
 

--- a/backend/app/schemas/tenant.py
+++ b/backend/app/schemas/tenant.py
@@ -2,6 +2,10 @@ from pydantic import BaseModel, EmailStr
 from typing import Optional, List
 from datetime import datetime, date
 from app.models.payment_schedule import PaymentFrequency
+from app.schemas.room import RoomResponse
+from app.schemas.property import PropertyResponse
+from app.schemas.payment_schedule import PaymentScheduleResponse
+from app.schemas.payment import PaymentResponse
 
 
 # Request schemas
@@ -109,6 +113,12 @@ class TenantWithDetails(TenantResponse):
     has_portal_access: bool = False
     pending_payments: int = 0
     overdue_payments: int = 0
+
+    # Nested objects for detail view (also present in list responses for type consistency)
+    room: Optional[RoomResponse] = None
+    property: Optional[PropertyResponse] = None
+    payment_schedule: Optional[PaymentScheduleResponse] = None
+    payments: List[PaymentResponse] = []
 
 
 class TenantListResponse(BaseModel):

--- a/backend/app/schemas/tenant.py
+++ b/backend/app/schemas/tenant.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 from typing import Optional, List
 from datetime import datetime, date
 from app.models.payment_schedule import PaymentFrequency
@@ -23,10 +23,10 @@ class TenantCreate(BaseModel):
     # If payment_amount is provided, uses that instead of room rent
     # Default is False so the frontend can create schedules via Step 2 of the modal
     auto_create_schedule: bool = False
-    payment_amount: Optional[float] = None  # Override room rent if provided
-    payment_frequency: Optional[PaymentFrequency] = PaymentFrequency.MONTHLY
-    payment_due_day: Optional[int] = 1  # 1st of month (standard)
-    payment_window_days: Optional[int] = None  # Will use property's grace_period_days
+    payment_amount: Optional[float] = Field(default=None, gt=0)  # Override room rent if provided
+    payment_frequency: Optional[PaymentFrequency] = PaymentFrequency.BI_MONTHLY
+    payment_due_day: Optional[int] = Field(default=1, ge=1, le=28)
+    payment_window_days: Optional[int] = Field(default=None, ge=1, le=15)
 
 
 class TenantUpdate(BaseModel):

--- a/backend/app/services/payment_service.py
+++ b/backend/app/services/payment_service.py
@@ -82,8 +82,8 @@ def create_prorated_payment(
         calendar.monthrange(move_in_date.year, move_in_date.month)[1],
     )
 
-    # Window end is 3 days after due date
-    window_end_date = due_date + relativedelta(days=3)
+    # Window end is 3 days after due date (inclusive: move-in day + 2 more days)
+    window_end_date = due_date + relativedelta(days=2)
 
     # Determine status based on current date
     today = date.today()
@@ -122,6 +122,30 @@ def get_frequency_months(frequency: PaymentFrequency) -> int:
     return 1
 
 
+def normalize_schedule_start(
+    start_date: date, due_day: int, window_days: int
+) -> date:
+    """
+    Align a schedule start date so the first payment window is not already closed.
+
+    If the supplied start_date falls after the payment window for that month,
+    push the schedule start to the first day of the next billing month.  This
+    prevents a newly-created schedule from immediately generating an overdue
+    payment when the landlord creates it mid-month.
+
+    The window is inclusive: [due_day, due_day + window_days - 1].
+    """
+    window_end_day = due_day + window_days - 1
+
+    # If we are still inside (or before) the window, start this month on the 1st.
+    if start_date.day <= window_end_day:
+        return date(start_date.year, start_date.month, 1)
+
+    # Otherwise start on the 1st of the next month.
+    next_month = start_date + relativedelta(months=1)
+    return date(next_month.year, next_month.month, 1)
+
+
 def calculate_next_period(
     schedule: PaymentSchedule, after_date: date
 ) -> tuple[date, date, date, date]:
@@ -151,7 +175,8 @@ def calculate_next_period(
     due_date = date(
         current_period_start.year, current_period_start.month, schedule.due_day
     )
-    window_end_date = due_date + relativedelta(days=schedule.window_days)
+    # Window is inclusive: e.g. due_day=1 with window_days=5 means 1st-5th.
+    window_end_date = due_date + relativedelta(days=schedule.window_days - 1)
 
     return current_period_start, period_end, due_date, window_end_date
 

--- a/backend/tests/api/routes/test_analytics.py
+++ b/backend/tests/api/routes/test_analytics.py
@@ -6,7 +6,7 @@ Tests all dashboard analytics endpoints and helper functions.
 import pytest
 from datetime import date, timedelta
 from fastapi.testclient import TestClient
-from sqlmodel import Session
+from sqlmodel import Session, select
 from dateutil.relativedelta import relativedelta
 
 from app.models.landlord import Landlord
@@ -123,6 +123,51 @@ def test_dashboard_includes_current_month_stats(
     assert current_month["received"] == 0.0
     assert current_month["outstanding"] == 1000000.0
     assert current_month["collection_rate"] == 0.0
+
+
+def test_dashboard_updates_stale_payment_statuses(
+    client: TestClient,
+    session: Session,
+    auth_landlord: Landlord,
+    auth_headers: dict,
+):
+    """Test that dashboard refreshes payment statuses before aggregating stats."""
+    prop = PropertyFactory.create(session=session, landlord_id=auth_landlord.id)
+    room = RoomFactory.create(
+        session=session,
+        property_id=prop.id,
+        rent_amount=1000000,
+        currency="UGX",
+        is_occupied=True,
+    )
+    tenant = TenantFactory.create(session=session, room_id=room.id)
+
+    today = date.today()
+    # Create a payment that was stored as UPCOMING but whose window has already
+    # closed, so it should be counted as overdue on the dashboard.
+    PaymentFactory.create(
+        session=session,
+        tenant_id=tenant.id,
+        amount_due=1000000,
+        due_date=today - timedelta(days=15),
+        window_end_date=today - timedelta(days=10),
+        status=PaymentStatus.UPCOMING,
+    )
+
+    response = client.get("/api/analytics/dashboard", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.json()
+
+    overdue = data["overdue_summary"]
+    assert overdue["count"] == 1
+    assert overdue["total_amount"] == 1000000.0
+
+    # The payment should have been persisted as OVERDUE.
+    db_payment = session.exec(
+        select(Payment).where(Payment.tenant_id == tenant.id)
+    ).first()
+    assert db_payment.status == PaymentStatus.OVERDUE
 
 
 def test_dashboard_includes_three_month_trend(
@@ -1499,6 +1544,7 @@ def test_dashboard_complete_with_overdue_and_vacancy(
         tenant_id=tenant2.id,
         amount_due=800000,
         due_date=date(today.year, today.month, 1),
+        window_end_date=today + timedelta(days=5),
         status=PaymentStatus.PENDING,
     )
 

--- a/backend/tests/api/routes/test_payments.py
+++ b/backend/tests/api/routes/test_payments.py
@@ -811,5 +811,5 @@ def test_summary_with_property_filter(
     data = response.json()
 
     # Should only include payments from property1
-    assert data["amount_outstanding"] == 100000
-    assert data["total_pending"] == 1
+    assert data["total_outstanding"] == 100000
+    assert data["pending_count"] == 1

--- a/backend/tests/api/routes/test_payments.py
+++ b/backend/tests/api/routes/test_payments.py
@@ -8,7 +8,7 @@ import os
 from datetime import date, timedelta
 from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app.models.landlord import Landlord
 from app.models.tenant import Tenant
@@ -444,6 +444,41 @@ def test_get_overdue_payments(
             "pending",
             "upcoming",
         ]  # Status gets updated
+
+
+def test_get_overdue_payments_preserves_verifying(
+    client: TestClient,
+    session: Session,
+    auth_landlord: Landlord,
+    auth_headers: dict,
+):
+    """Test that VERIFYING payments are not overwritten by the overdue endpoint."""
+    prop = PropertyFactory.create(session=session, landlord_id=auth_landlord.id)
+    room = RoomFactory.create(session=session, property_id=prop.id)
+    tenant = TenantFactory.create(session=session, room_id=room.id)
+
+    today = date.today()
+    schedule = PaymentScheduleFactory.create(session=session, tenant_id=tenant.id)
+
+    PaymentFactory.create(
+        session=session,
+        tenant_id=tenant.id,
+        schedule_id=schedule.id,
+        status=PaymentStatus.VERIFYING,
+        due_date=today - timedelta(days=15),
+        window_end_date=today - timedelta(days=10),
+    )
+
+    response = client.get("/api/payments/overdue", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 0
+    # Verify the payment is still VERIFYING in the database
+    db_payment = session.exec(
+        select(Payment).where(Payment.tenant_id == tenant.id)
+    ).first()
+    assert db_payment.status == PaymentStatus.VERIFYING
 
 
 # =============================================================================

--- a/backend/tests/api/routes/test_payments.py
+++ b/backend/tests/api/routes/test_payments.py
@@ -1004,3 +1004,58 @@ def test_summary_property_filter_scopes_to_landlord(
     )
 
     assert response.status_code == 404
+
+
+def test_summary_converts_mixed_currencies(
+    client: TestClient,
+    session: Session,
+    auth_landlord: Landlord,
+    auth_headers: dict,
+):
+    """Test that payment summary converts mixed room currencies to landlord currency."""
+    from tests.factories import PropertyFactory, RoomFactory
+
+    prop1 = PropertyFactory.create(session=session, landlord_id=auth_landlord.id)
+    room1 = RoomFactory.create(
+        session=session, property_id=prop1.id, rent_amount=100, currency="USD"
+    )
+    tenant1 = TenantFactory.create(session=session, room_id=room1.id)
+
+    prop2 = PropertyFactory.create(session=session, landlord_id=auth_landlord.id)
+    room2 = RoomFactory.create(
+        session=session, property_id=prop2.id, rent_amount=100000, currency="UGX"
+    )
+    tenant2 = TenantFactory.create(session=session, room_id=room2.id)
+
+    today = date.today()
+    schedule1 = PaymentScheduleFactory.create(session=session, tenant_id=tenant1.id)
+    schedule2 = PaymentScheduleFactory.create(session=session, tenant_id=tenant2.id)
+
+    PaymentFactory.create(
+        session=session,
+        tenant_id=tenant1.id,
+        schedule_id=schedule1.id,
+        status=PaymentStatus.PENDING,
+        due_date=today,
+        window_end_date=today + timedelta(days=5),
+        period_end=today + timedelta(days=30),
+        amount_due=100,
+    )
+    PaymentFactory.create(
+        session=session,
+        tenant_id=tenant2.id,
+        schedule_id=schedule2.id,
+        status=PaymentStatus.PENDING,
+        due_date=today,
+        window_end_date=today + timedelta(days=5),
+        period_end=today + timedelta(days=30),
+        amount_due=100000,
+    )
+
+    response = client.get("/api/payments/summary", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.json()
+    # USD 100 -> UGX 375,000; UGX 100,000 -> UGX 100,000; total = 475,000
+    assert data["total_outstanding"] == 475000.0
+    assert data["pending_count"] == 2

--- a/backend/tests/api/routes/test_payments.py
+++ b/backend/tests/api/routes/test_payments.py
@@ -408,6 +408,54 @@ def test_get_upcoming_payments(
         assert days_until <= 30
 
 
+def test_get_upcoming_payments_with_property_filter(
+    client: TestClient,
+    session: Session,
+    auth_landlord: Landlord,
+    auth_headers: dict,
+):
+    """Test that upcoming endpoint respects property_id filter."""
+    property1 = PropertyFactory.create(
+        session=session, landlord_id=auth_landlord.id, name="Property 1"
+    )
+    room1 = RoomFactory.create(session=session, property_id=property1.id)
+    tenant1 = TenantFactory.create(session=session, room_id=room1.id)
+
+    property2 = PropertyFactory.create(
+        session=session, landlord_id=auth_landlord.id, name="Property 2"
+    )
+    room2 = RoomFactory.create(session=session, property_id=property2.id)
+    tenant2 = TenantFactory.create(session=session, room_id=room2.id)
+
+    today = date.today()
+    schedule1 = PaymentScheduleFactory.create(session=session, tenant_id=tenant1.id)
+    schedule2 = PaymentScheduleFactory.create(session=session, tenant_id=tenant2.id)
+
+    PaymentFactory.create(
+        session=session,
+        tenant_id=tenant1.id,
+        schedule_id=schedule1.id,
+        status=PaymentStatus.UPCOMING,
+        due_date=today + timedelta(days=7),
+    )
+    PaymentFactory.create(
+        session=session,
+        tenant_id=tenant2.id,
+        schedule_id=schedule2.id,
+        status=PaymentStatus.UPCOMING,
+        due_date=today + timedelta(days=7),
+    )
+
+    response = client.get(
+        f"/api/payments/upcoming?days=30&property_id={property1.id}",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+
+
 def test_get_overdue_payments(
     client: TestClient,
     session: Session,
@@ -444,6 +492,56 @@ def test_get_overdue_payments(
             "pending",
             "upcoming",
         ]  # Status gets updated
+
+
+def test_get_overdue_payments_with_property_filter(
+    client: TestClient,
+    session: Session,
+    auth_landlord: Landlord,
+    auth_headers: dict,
+):
+    """Test that overdue endpoint respects property_id filter."""
+    property1 = PropertyFactory.create(
+        session=session, landlord_id=auth_landlord.id, name="Property 1"
+    )
+    room1 = RoomFactory.create(session=session, property_id=property1.id)
+    tenant1 = TenantFactory.create(session=session, room_id=room1.id)
+
+    property2 = PropertyFactory.create(
+        session=session, landlord_id=auth_landlord.id, name="Property 2"
+    )
+    room2 = RoomFactory.create(session=session, property_id=property2.id)
+    tenant2 = TenantFactory.create(session=session, room_id=room2.id)
+
+    today = date.today()
+    schedule1 = PaymentScheduleFactory.create(session=session, tenant_id=tenant1.id)
+    schedule2 = PaymentScheduleFactory.create(session=session, tenant_id=tenant2.id)
+
+    PaymentFactory.create(
+        session=session,
+        tenant_id=tenant1.id,
+        schedule_id=schedule1.id,
+        status=PaymentStatus.OVERDUE,
+        due_date=today - timedelta(days=15),
+        window_end_date=today - timedelta(days=10),
+    )
+    PaymentFactory.create(
+        session=session,
+        tenant_id=tenant2.id,
+        schedule_id=schedule2.id,
+        status=PaymentStatus.OVERDUE,
+        due_date=today - timedelta(days=15),
+        window_end_date=today - timedelta(days=10),
+    )
+
+    response = client.get(
+        f"/api/payments/overdue?property_id={property1.id}",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
 
 
 # =============================================================================
@@ -691,6 +789,40 @@ def test_waive_without_notes(
     assert data["status"].lower() == "waived"
 
 
+def test_waive_saves_notes(
+    client: TestClient,
+    session: Session,
+    auth_landlord: Landlord,
+    auth_headers: dict,
+):
+    """Test that the waiver reason/notes are persisted on the payment."""
+    prop = PropertyFactory.create(session=session, landlord_id=auth_landlord.id)
+    room = RoomFactory.create(session=session, property_id=prop.id)
+    tenant = TenantFactory.create(session=session, room_id=room.id)
+
+    schedule = PaymentScheduleFactory.create(session=session, tenant_id=tenant.id)
+    payment = PaymentFactory.create(
+        session=session,
+        tenant_id=tenant.id,
+        schedule_id=schedule.id,
+        status=PaymentStatus.PENDING,
+    )
+
+    response = client.put(
+        f"/api/payments/{payment.id}/waive",
+        headers=auth_headers,
+        json={"notes": "Tenant lost their job"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"].lower() == "waived"
+    assert data["notes"] == "Tenant lost their job"
+
+    session.refresh(payment)
+    assert payment.notes == "Tenant lost their job"
+
+
 def test_list_payments_with_property_filter(
     client: TestClient,
     session: Session,
@@ -813,3 +945,27 @@ def test_summary_with_property_filter(
     # Should only include payments from property1
     assert data["total_outstanding"] == 100000
     assert data["pending_count"] == 1
+
+
+def test_summary_property_filter_scopes_to_landlord(
+    client: TestClient,
+    session: Session,
+    auth_landlord: Landlord,
+    auth_headers: dict,
+):
+    """Test that summary property filter cannot access another landlord's property."""
+    from tests.factories import LandlordFactory
+
+    other_landlord = LandlordFactory.create(
+        session=session, email="other-summary@test.com"
+    )
+    other_property = PropertyFactory.create(
+        session=session, landlord_id=other_landlord.id, name="Other Property"
+    )
+
+    response = client.get(
+        f"/api/payments/summary?property_id={other_property.id}",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 404

--- a/backend/tests/api/routes/test_properties.py
+++ b/backend/tests/api/routes/test_properties.py
@@ -207,14 +207,14 @@ def test_create_property_invalid_data(client: TestClient, auth_headers: dict):
 def test_create_property_with_grace_period(
     client: TestClient, auth_landlord: Landlord, auth_headers: dict
 ):
-    """Test creating a property with custom grace period."""
-    # Note: grace_period_days is in schema but not implemented in router
+    """Test creating a property persists the grace period."""
     property_data = {"name": "Property with Grace", "grace_period_days": 10}
 
     response = client.post("/api/properties", headers=auth_headers, json=property_data)
 
     assert response.status_code == 201
-    # grace_period_days not currently handled by router - field exists in schema for future use
+    data = response.json()
+    assert data["grace_period_days"] == 10
 
 
 # =============================================================================
@@ -362,6 +362,31 @@ def test_update_property_partial(
     assert data["name"] == "New Name Only"
     assert data["address"] == "Original Address"  # Unchanged
     assert data["description"] == "Original Description"  # Unchanged
+
+
+def test_update_property_grace_period(
+    client: TestClient, session: Session, auth_landlord: Landlord, auth_headers: dict
+):
+    """Test updating a property persists a new grace period."""
+    from tests.factories import PropertyFactory
+
+    prop = PropertyFactory.create(
+        session=session,
+        landlord_id=auth_landlord.id,
+        name="Original Name",
+        grace_period_days=5,
+    )
+
+    update_data = {"grace_period_days": 12}
+
+    response = client.put(
+        f"/api/properties/{prop.id}", headers=auth_headers, json=update_data
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["grace_period_days"] == 12
+    assert data["name"] == "Original Name"  # Unchanged
 
 
 def test_update_property_not_found(client: TestClient, auth_headers: dict):

--- a/backend/tests/api/routes/test_tenants.py
+++ b/backend/tests/api/routes/test_tenants.py
@@ -1438,6 +1438,7 @@ def test_create_tenant_different_frequencies(
             "email": f"{freq}@example.com",
             "move_in_date": date(2024, 1, 1).isoformat(),
             "payment_frequency": freq,
+            "auto_create_schedule": True,
         }
 
         response = client.post("/api/tenants", headers=auth_headers, json=tenant_data)
@@ -1539,6 +1540,7 @@ def test_create_tenant_custom_due_day(
         "email": "customdue@example.com",
         "move_in_date": date(2024, 1, 1).isoformat(),
         "payment_due_day": 15,  # 15th of month
+        "auto_create_schedule": True,
     }
 
     response = client.post("/api/tenants", headers=auth_headers, json=tenant_data)
@@ -1570,6 +1572,7 @@ def test_create_tenant_custom_window_days(
         "email": "customwindow@example.com",
         "move_in_date": date(2024, 1, 1).isoformat(),
         "payment_window_days": 10,  # 10 day window
+        "auto_create_schedule": True,
     }
 
     response = client.post("/api/tenants", headers=auth_headers, json=tenant_data)

--- a/backend/tests/api/routes/test_tenants.py
+++ b/backend/tests/api/routes/test_tenants.py
@@ -322,7 +322,7 @@ def test_create_tenant_with_auto_schedule(
     ).first()
     assert schedule is not None
     assert schedule.amount == test_room.rent_amount
-    assert schedule.frequency == PaymentFrequency.MONTHLY
+    assert schedule.frequency == PaymentFrequency.BI_MONTHLY
 
     # Verify first payment was generated
     payment = session.exec(
@@ -330,6 +330,35 @@ def test_create_tenant_with_auto_schedule(
     ).first()
     assert payment is not None
     assert payment.amount_due == test_room.rent_amount
+
+
+def test_create_tenant_default_frequency_is_bi_monthly(
+    client: TestClient,
+    session: Session,
+    auth_landlord: Landlord,
+    auth_headers: dict,
+    test_property: Property,
+    test_room: Room,
+):
+    """Test that tenant schedule defaults to bi-monthly when not specified."""
+    from app.models.payment_schedule import PaymentSchedule
+
+    tenant_data = {
+        "room_id": test_room.id,
+        "name": "Default Frequency Tenant",
+        "email": "defaultfreq@example.com",
+        "move_in_date": date(2024, 1, 1).isoformat(),
+        "auto_create_schedule": True,
+    }
+
+    response = client.post("/api/tenants", headers=auth_headers, json=tenant_data)
+
+    assert response.status_code == 201
+    schedule = session.exec(
+        select(PaymentSchedule).where(PaymentSchedule.tenant_id == response.json()["id"])
+    ).first()
+    assert schedule is not None
+    assert schedule.frequency == PaymentFrequency.BI_MONTHLY
 
 
 def test_create_tenant_without_auto_schedule(
@@ -1085,6 +1114,87 @@ def test_create_tenant_schedule_not_found(client: TestClient, auth_headers: dict
         json=schedule_data,
     )
     assert response.status_code == 404
+
+
+def test_create_tenant_schedule_rejects_zero_window_days(
+    client: TestClient,
+    session: Session,
+    auth_landlord: Landlord,
+    auth_headers: dict,
+    test_room: Room,
+):
+    """Test that window_days must be at least 1."""
+    from tests.factories import TenantFactory
+
+    tenant = TenantFactory.create(session=session, room_id=test_room.id)
+
+    schedule_data = {
+        "amount": 1500000,
+        "frequency": "monthly",
+        "due_day": 1,
+        "window_days": 0,
+        "start_date": date(2024, 1, 1).isoformat(),
+    }
+
+    response = client.post(
+        f"/api/tenants/{tenant.id}/schedule", headers=auth_headers, json=schedule_data
+    )
+
+    assert response.status_code == 422
+
+
+def test_create_tenant_schedule_rejects_invalid_due_day(
+    client: TestClient,
+    session: Session,
+    auth_landlord: Landlord,
+    auth_headers: dict,
+    test_room: Room,
+):
+    """Test that due_day is constrained to 1-28."""
+    from tests.factories import TenantFactory
+
+    tenant = TenantFactory.create(session=session, room_id=test_room.id)
+
+    schedule_data = {
+        "amount": 1500000,
+        "frequency": "monthly",
+        "due_day": 31,
+        "window_days": 5,
+        "start_date": date(2024, 1, 1).isoformat(),
+    }
+
+    response = client.post(
+        f"/api/tenants/{tenant.id}/schedule", headers=auth_headers, json=schedule_data
+    )
+
+    assert response.status_code == 422
+
+
+def test_create_tenant_schedule_rejects_zero_amount(
+    client: TestClient,
+    session: Session,
+    auth_landlord: Landlord,
+    auth_headers: dict,
+    test_room: Room,
+):
+    """Test that schedule amount must be greater than 0."""
+    from tests.factories import TenantFactory
+
+    tenant = TenantFactory.create(session=session, room_id=test_room.id)
+
+    schedule_data = {
+        "amount": 0,
+        "frequency": "monthly",
+        "due_day": 1,
+        "window_days": 5,
+        "start_date": date(2024, 1, 1).isoformat(),
+    }
+
+    response = client.post(
+        f"/api/tenants/{tenant.id}/schedule", headers=auth_headers, json=schedule_data
+    )
+
+    assert response.status_code == 422
 
 
 def test_update_tenant_schedule_success(

--- a/backend/tests/api/routes/test_tenants.py
+++ b/backend/tests/api/routes/test_tenants.py
@@ -1040,6 +1040,58 @@ def test_create_tenant_schedule_success(
     assert schedule is not None
 
 
+def test_create_tenant_schedule_normalizes_start_after_window(
+    client: TestClient,
+    session: Session,
+    auth_landlord: Landlord,
+    auth_headers: dict,
+    test_room: Room,
+):
+    """Test that a schedule created after the payment window starts next month."""
+    from unittest.mock import patch
+    from tests.factories import TenantFactory
+    from app.models.payment_schedule import PaymentSchedule
+    from app.models.payment import Payment, PaymentStatus
+
+    tenant = TenantFactory.create(session=session, room_id=test_room.id)
+
+    # June 15 is after the 1st-5th window, so the schedule should roll to July 1.
+    schedule_data = {
+        "amount": 1500000,
+        "frequency": "monthly",
+        "due_day": 1,
+        "window_days": 5,
+        "start_date": date(2024, 6, 15).isoformat(),
+    }
+
+    # Freeze "today" to the creation date so the first payment is not already
+    # past its window.
+    with patch("app.services.payment_service.date") as mock_date:
+        mock_date.today.return_value = date(2024, 6, 15)
+        mock_date.side_effect = lambda *args, **kwargs: date(*args, **kwargs)
+        response = client.post(
+            f"/api/tenants/{tenant.id}/schedule",
+            headers=auth_headers,
+            json=schedule_data,
+        )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["start_date"] == date(2024, 7, 1).isoformat()
+
+    schedule = session.exec(
+        select(PaymentSchedule).where(PaymentSchedule.tenant_id == tenant.id)
+    ).first()
+    assert schedule.start_date == date(2024, 7, 1)
+
+    # The generated first payment should not be immediately overdue.
+    payment = session.exec(
+        select(Payment).where(Payment.schedule_id == schedule.id)
+    ).first()
+    assert payment is not None
+    assert payment.status != PaymentStatus.OVERDUE
+
+
 def test_create_tenant_schedule_already_exists(
     client: TestClient,
     session: Session,

--- a/backend/tests/api/routes/test_tenants.py
+++ b/backend/tests/api/routes/test_tenants.py
@@ -511,6 +511,46 @@ def test_create_tenant_no_proration_before_5th(
     assert payments[0].is_manual is False  # Not a manual prorated payment
 
 
+def test_create_tenant_no_overlap_when_schedule_starts_current_month(
+    client: TestClient,
+    session: Session,
+    auth_landlord: Landlord,
+    auth_headers: dict,
+    test_property: Property,
+    test_room: Room,
+):
+    """Test that a mid-month move-in within the window does not create a second prorated charge."""
+    from app.models.payment import Payment
+
+    # Move in on the 10th with due day 15 and a 5-day window (10th-19th).
+    # The schedule starts in the current month, so the scheduled payment already
+    # covers the period and no prorated manual payment should be created.
+    move_in_date = date(2024, 6, 10)
+
+    tenant_data = {
+        "room_id": test_room.id,
+        "name": "Mid-window Tenant",
+        "email": "midwindow@example.com",
+        "move_in_date": move_in_date.isoformat(),
+        "payment_due_day": 15,
+        "payment_window_days": 5,
+        "auto_create_schedule": True,
+    }
+
+    response = client.post("/api/tenants", headers=auth_headers, json=tenant_data)
+
+    assert response.status_code == 201
+    data = response.json()
+
+    payments = session.exec(
+        select(Payment).where(Payment.tenant_id == data["id"])
+    ).all()
+
+    # Only the scheduled payment should exist; no manual prorated payment.
+    assert len(payments) == 1
+    assert payments[0].is_manual is False
+
+
 def test_create_tenant_occupied_room_fails(
     client: TestClient,
     session: Session,

--- a/backend/tests/integration/test_workflows.py
+++ b/backend/tests/integration/test_workflows.py
@@ -688,9 +688,9 @@ class TestWorkflow4MultiTenantProperty:
         )
         summary_data = summary_response.json()
         # 3 paid on time + 1 paid late = 4 total paid this month
-        assert summary_data["total_paid_this_month"] == 4
+        assert summary_data["paid_count"] == 4
         # 1 tenant still pending
-        assert summary_data["total_pending"] == 1
+        assert summary_data["pending_count"] == 1
 
 
 # =============================================================================

--- a/backend/tests/integration/test_workflows.py
+++ b/backend/tests/integration/test_workflows.py
@@ -772,7 +772,10 @@ class TestWorkflow3DemoPath:
 
         # Step 4: Add tenant to the first room
         today = date.today()
-        move_in_date = today.replace(day=1)
+        # Use today as the move-in / schedule start so the generated payment's
+        # due date lands in the next billing period (future) and can be marked
+        # on time during the test run.
+        move_in_date = today
         tenant_response = client.post(
             "/api/tenants",
             headers=landlord_headers,
@@ -822,11 +825,14 @@ class TestWorkflow3DemoPath:
         assert payment["currency"] == "UGX"
 
         # Step 7: Mark payment paid with receipt reference
+        # Use the payment's due date as the paid date so it is recorded on time
+        # regardless of the current calendar day.
         mark_paid_response = client.put(
             f"/api/payments/{payment['id']}/mark-paid",
             headers=landlord_headers,
             json={
                 "payment_reference": "REF-DEMO-001",
+                "paid_date": payment["due_date"],
                 "notes": "Received via bank transfer",
             },
         )

--- a/backend/tests/integration/test_workflows.py
+++ b/backend/tests/integration/test_workflows.py
@@ -694,6 +694,194 @@ class TestWorkflow4MultiTenantProperty:
 
 
 # =============================================================================
+# Workflow 3: Demo Path - Manual Bi-Monthly Schedule and Payment Collection
+# =============================================================================
+
+
+class TestWorkflow3DemoPath:
+    """
+    Real demo path exercised by the frontend:
+    1. Landlord registers and logs in
+    2. Landlord adds a property
+    3. Landlord bulk creates rooms
+    4. Landlord adds a tenant (without auto-created schedule)
+    5. Landlord creates a bi_monthly payment schedule
+    6. A payment appears for the tenant
+    7. Landlord marks the payment paid with a receipt reference
+    8. Payment summary totals update to reflect the received amount
+    """
+
+    def test_demo_path_bi_monthly_schedule_and_mark_paid(
+        self, client: TestClient, session: Session
+    ):
+        """End-to-end demo path with bi-monthly schedule and mark paid."""
+        # Step 1: Register and log in as a landlord
+        register_response = client.post(
+            "/api/auth/register",
+            json={
+                "name": "Demo Landlord",
+                "email": "demo.landlord@test.com",
+                "password": "demopass123",
+                "phone": "555-9999",
+            },
+        )
+        assert register_response.status_code == 201
+        login_response = client.post(
+            "/api/auth/login",
+            json={"email": "demo.landlord@test.com", "password": "demopass123"},
+        )
+        assert login_response.status_code == 200
+        login_data = login_response.json()
+        landlord_headers = {
+            "Authorization": f"Bearer {login_data['access_token']}"
+        }
+
+        # Step 2: Add property
+        property_response = client.post(
+            "/api/properties",
+            headers=landlord_headers,
+            json={
+                "name": "Makerere Hostel",
+                "address": "Makerere Hill Road, Kampala",
+                "description": "Demo property for end-to-end test",
+                "grace_period_days": 5,
+            },
+        )
+        assert property_response.status_code == 201
+        property_id = property_response.json()["id"]
+
+        # Step 3: Bulk create rooms
+        bulk_response = client.post(
+            f"/api/properties/{property_id}/rooms/bulk",
+            headers=landlord_headers,
+            json={
+                "prefix": "L",
+                "from_number": 1,
+                "to_number": 10,
+                "currency": "UGX",
+                "price_ranges": [
+                    {"from_number": 1, "to_number": 10, "rent_amount": 450000}
+                ],
+                "padding": 3,
+            },
+        )
+        assert bulk_response.status_code == 201
+        bulk_data = bulk_response.json()
+        assert bulk_data["total_created"] == 10
+        rooms = bulk_data["created"]
+
+        # Step 4: Add tenant to the first room
+        today = date.today()
+        move_in_date = today.replace(day=1)
+        tenant_response = client.post(
+            "/api/tenants",
+            headers=landlord_headers,
+            json={
+                "room_id": rooms[0]["id"],
+                "name": "Demo Tenant",
+                "email": "demo.tenant@test.com",
+                "phone": "555-0001",
+                "move_in_date": move_in_date.isoformat(),
+                "auto_create_schedule": False,
+            },
+        )
+        assert tenant_response.status_code == 201
+        tenant_data = tenant_response.json()
+        tenant_id = tenant_data["id"]
+        assert tenant_data["has_payment_schedule"] is False
+        assert tenant_data["room"]["name"] == "L001"
+        assert tenant_data["property"]["name"] == "Makerere Hostel"
+
+        # Step 5: Create bi_monthly payment schedule
+        schedule_response = client.post(
+            f"/api/tenants/{tenant_id}/schedule",
+            headers=landlord_headers,
+            json={
+                "amount": 450000,
+                "frequency": "bi_monthly",
+                "due_day": 1,
+                "window_days": 5,
+                "start_date": move_in_date.isoformat(),
+            },
+        )
+        assert schedule_response.status_code == 201
+        schedule_data = schedule_response.json()
+        assert schedule_data["frequency"] == "bi_monthly"
+
+        # Step 6: Verify payment appears
+        payments_response = client.get(
+            "/api/payments",
+            headers=landlord_headers,
+        )
+        assert payments_response.status_code == 200
+        payments_data = payments_response.json()
+        assert payments_data["total"] == 1
+        payment = payments_data["payments"][0]
+        assert payment["tenant_id"] == tenant_id
+        assert payment["amount_due"] == 450000
+        assert payment["currency"] == "UGX"
+
+        # Step 7: Mark payment paid with receipt reference
+        mark_paid_response = client.put(
+            f"/api/payments/{payment['id']}/mark-paid",
+            headers=landlord_headers,
+            json={
+                "payment_reference": "REF-DEMO-001",
+                "notes": "Received via bank transfer",
+            },
+        )
+        assert mark_paid_response.status_code == 200
+        paid_payment = mark_paid_response.json()
+        assert paid_payment["status"] == "on_time"
+        assert paid_payment["payment_reference"] == "REF-DEMO-001"
+
+        # Step 8: Verify payment summary totals update
+        summary_response = client.get(
+            "/api/payments/summary",
+            headers=landlord_headers,
+        )
+        assert summary_response.status_code == 200
+        summary = summary_response.json()
+        assert summary["total_received"] == 450000
+        assert summary["total_expected"] == 450000
+        assert summary["total_outstanding"] == 0
+        assert summary["paid_count"] == 1
+
+        # Verify tenant detail now includes the paid payment
+        tenant_detail_response = client.get(
+            f"/api/tenants/{tenant_id}",
+            headers=landlord_headers,
+        )
+        assert tenant_detail_response.status_code == 200
+        tenant_detail = tenant_detail_response.json()
+        assert tenant_detail["has_payment_schedule"] is True
+        assert len(tenant_detail["payments"]) == 1
+        assert tenant_detail["payments"][0]["status"] == "on_time"
+
+        # Verify duplicate bulk creation skips existing rooms
+        duplicate_bulk_response = client.post(
+            f"/api/properties/{property_id}/rooms/bulk",
+            headers=landlord_headers,
+            json={
+                "prefix": "L",
+                "from_number": 1,
+                "to_number": 5,
+                "currency": "UGX",
+                "price_ranges": [
+                    {"from_number": 1, "to_number": 5, "rent_amount": 500000}
+                ],
+                "padding": 3,
+            },
+        )
+        assert duplicate_bulk_response.status_code == 201
+        duplicate_data = duplicate_bulk_response.json()
+        assert duplicate_data["total_created"] == 0
+        assert any(
+            "already exists" in warning for warning in duplicate_data["warnings"]
+        )
+
+
+# =============================================================================
 # Workflow 5: Move-Out and New Tenant
 # =============================================================================
 

--- a/backend/tests/test_services/test_payment_service.py
+++ b/backend/tests/test_services/test_payment_service.py
@@ -19,6 +19,7 @@ from app.services.payment_service import (
     update_payment_statuses,
     get_payments_entering_window,
     get_payments_becoming_overdue,
+    normalize_schedule_start,
 )
 from app.models.payment import Payment, PaymentStatus
 from app.models.payment_schedule import PaymentSchedule, PaymentFrequency
@@ -241,7 +242,7 @@ class TestCreateProratedPayment:
     @patch("app.services.payment_service.date")
     def test_status_pending_when_in_window(self, mock_date, session):
         """Test PENDING status when today is in payment window."""
-        # Due date is 18th, window ends 21st
+        # Due date is 18th, inclusive 3-day window ends 20th
         setup_date_mock(mock_date, date(2024, 1, 19))
         scenario = create_full_test_scenario(session)
         tenant = scenario["tenant"]
@@ -259,7 +260,7 @@ class TestCreateProratedPayment:
     @patch("app.services.payment_service.date")
     def test_status_overdue_when_after_window(self, mock_date, session):
         """Test OVERDUE status when today is after window end."""
-        # Window ends on 21st
+        # Window ends on 20th
         setup_date_mock(mock_date, date(2024, 1, 25))
         scenario = create_full_test_scenario(session)
         tenant = scenario["tenant"]
@@ -291,8 +292,8 @@ class TestCreateProratedPayment:
         assert payment.period_end == date(2024, 1, 31)
         # Due date is 3 days from move-in
         assert payment.due_date == date(2024, 1, 18)
-        # Window is 3 days after due date
-        assert payment.window_end_date == date(2024, 1, 21)
+        # Inclusive 3-day window ends 2 days after due date
+        assert payment.window_end_date == date(2024, 1, 20)
 
     def test_payment_saved_to_database(self, session):
         """Test that created payment is persisted."""
@@ -344,6 +345,44 @@ class TestGetFrequencyMonths:
 
 
 # =============================================================================
+# Tests for normalize_schedule_start
+# =============================================================================
+
+
+class TestNormalizeScheduleStart:
+    """Test schedule start alignment so the first window is not already closed."""
+
+    def test_start_inside_window_uses_current_month(self):
+        """Start on the window end day -> schedule starts 1st of current month."""
+        result = normalize_schedule_start(date(2024, 6, 5), due_day=1, window_days=5)
+        assert result == date(2024, 6, 1)
+
+    def test_start_before_window_uses_current_month(self):
+        """Start before the window -> schedule starts 1st of current month."""
+        result = normalize_schedule_start(date(2024, 6, 3), due_day=1, window_days=5)
+        assert result == date(2024, 6, 1)
+
+    def test_start_after_window_rolls_to_next_month(self):
+        """Start after the window -> schedule starts 1st of next month."""
+        result = normalize_schedule_start(date(2024, 6, 15), due_day=1, window_days=5)
+        assert result == date(2024, 7, 1)
+
+    def test_uses_supplied_due_day(self):
+        """Window is computed from the schedule's due day, not hardcoded to 1."""
+        # due_day=10, window_days=5 -> window ends on the 14th
+        result = normalize_schedule_start(date(2024, 6, 16), due_day=10, window_days=5)
+        assert result == date(2024, 7, 1)
+
+        result = normalize_schedule_start(date(2024, 6, 12), due_day=10, window_days=5)
+        assert result == date(2024, 6, 1)
+
+    def test_year_boundary_rollover(self):
+        """Rolling from December to January works correctly."""
+        result = normalize_schedule_start(date(2024, 12, 20), due_day=1, window_days=5)
+        assert result == date(2025, 1, 1)
+
+
+# =============================================================================
 # Tests for calculate_next_period
 # =============================================================================
 
@@ -371,7 +410,8 @@ class TestCalculateNextPeriod:
         assert period_start == date(2024, 1, 1)
         assert period_end == date(2024, 1, 31)
         assert due_date == date(2024, 1, 5)
-        assert window_end == date(2024, 1, 8)
+        # Inclusive 3-day window: 5th, 6th, 7th
+        assert window_end == date(2024, 1, 7)
 
     def test_bi_monthly_period_calculation(self, session):
         """Test period calculation for bi-monthly schedule."""
@@ -393,7 +433,8 @@ class TestCalculateNextPeriod:
         assert period_start == date(2024, 1, 1)
         assert period_end == date(2024, 2, 29)  # 2024 is leap year
         assert due_date == date(2024, 1, 10)
-        assert window_end == date(2024, 1, 15)
+        # Inclusive 5-day window: 10th-14th
+        assert window_end == date(2024, 1, 14)
 
     def test_quarterly_period_calculation(self, session):
         """Test period calculation for quarterly schedule."""
@@ -415,7 +456,8 @@ class TestCalculateNextPeriod:
         assert period_start == date(2024, 1, 1)
         assert period_end == date(2024, 3, 31)
         assert due_date == date(2024, 1, 1)
-        assert window_end == date(2024, 1, 8)
+        # Inclusive 7-day window: 1st-7th
+        assert window_end == date(2024, 1, 7)
 
     def test_finds_period_after_given_date(self, session):
         """Test that it finds the period that ends on or after the given date."""
@@ -479,7 +521,8 @@ class TestCalculateNextPeriod:
         assert period_start == date(2024, 12, 1)
         assert period_end == date(2024, 12, 31)
         assert due_date == date(2024, 12, 15)
-        assert window_end == date(2024, 12, 18)
+        # Inclusive 3-day window: 15th-17th
+        assert window_end == date(2024, 12, 17)
 
 
 # =============================================================================

--- a/frontend/src/app/dashboard/leases/page.tsx
+++ b/frontend/src/app/dashboard/leases/page.tsx
@@ -78,10 +78,37 @@ export default function LeasesPage() {
     });
   };
 
-  const openLeaseUrl = (url?: string) => {
-    if (!url) return;
-    const apiBase = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
-    window.open(`${apiBase}${url}`, "_blank");
+  const openDownload = async (downloadPromise: Promise<Blob>, filename: string) => {
+    try {
+      const blob = await downloadPromise;
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error("Failed to download lease:", error);
+      alert("Failed to download lease file. Please try again.");
+    }
+  };
+
+  const openOriginalLease = (lease: LeaseAgreementWithTenant) => {
+    if (!lease.original_url) return;
+    void openDownload(
+      api.downloadOriginalLease(lease.id),
+      `${lease.tenant_name || "lease"}_original.pdf`
+    );
+  };
+
+  const openSignedLease = (lease: LeaseAgreementWithTenant) => {
+    if (!lease.signed_url) return;
+    void openDownload(
+      api.downloadSignedLease(lease.id),
+      `${lease.tenant_name || "lease"}_signed.pdf`
+    );
   };
 
   const statusConfig = {
@@ -347,7 +374,7 @@ export default function LeasesPage() {
 
                   <div className="grid grid-cols-2 gap-2 pt-1">
                     <button
-                      onClick={() => openLeaseUrl(lease.original_url)}
+                      onClick={() => openOriginalLease(lease)}
                       className="btn btn-secondary min-h-11"
                       title="View Original"
                     >
@@ -365,7 +392,7 @@ export default function LeasesPage() {
                       </button>
                     ) : (
                       <button
-                        onClick={() => openLeaseUrl(lease.signed_url)}
+                        onClick={() => openSignedLease(lease)}
                         className="btn btn-secondary min-h-11"
                         title="View Signed"
                         disabled={!lease.signed_url}
@@ -462,7 +489,7 @@ export default function LeasesPage() {
                       <td>
                         <div className="flex items-center justify-end gap-1">
                           <button
-                            onClick={() => openLeaseUrl(lease.original_url)}
+                            onClick={() => openOriginalLease(lease)}
                             className="btn btn-sm btn-ghost min-h-11 min-w-11"
                             title="View Original"
                           >
@@ -479,7 +506,7 @@ export default function LeasesPage() {
                           )}
                           {lease.signed_url && (
                               <button
-                                onClick={() => openLeaseUrl(lease.signed_url)}
+                                onClick={() => openSignedLease(lease)}
                                 className="btn btn-sm btn-ghost text-[var(--success)] min-h-11 min-w-11"
                                 title="View Signed"
                               >

--- a/frontend/src/app/dashboard/leases/page.tsx
+++ b/frontend/src/app/dashboard/leases/page.tsx
@@ -7,6 +7,7 @@ import api, {
   PropertyWithStats,
   TenantWithDetails,
 } from "@/lib/api";
+import { formatCurrency } from "@/lib/utils";
 import {
   FileText,
   Upload,
@@ -67,15 +68,6 @@ export default function LeasesPage() {
       lease.property_name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
       lease.room_name?.toLowerCase().includes(searchQuery.toLowerCase())
   );
-
-  const formatCurrency = (amount: number) => {
-    if (!amount) return "-";
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 0,
-    }).format(amount);
-  };
 
   const formatDate = (dateStr?: string) => {
     if (!dateStr) return "-";

--- a/frontend/src/app/dashboard/payments/page.tsx
+++ b/frontend/src/app/dashboard/payments/page.tsx
@@ -26,6 +26,7 @@ import {
   Download,
 } from "lucide-react";
 import ExportModal from "./ExportModal";
+import { formatCurrency } from "@/lib/utils";
 
 export default function PaymentsPage() {
   const [payments, setPayments] = useState<PaymentWithTenant[]>([]);
@@ -82,14 +83,6 @@ export default function PaymentsPage() {
       payment.room_name?.toLowerCase().includes(q)
     );
   });
-
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 0,
-    }).format(amount);
-  };
 
   const formatDate = (dateStr: string) => {
     return new Date(dateStr).toLocaleDateString("en-US", {
@@ -366,7 +359,7 @@ export default function PaymentsPage() {
                   <div className="grid grid-cols-2 gap-3 text-sm">
                     <div>
                       <p className="text-[var(--text-muted)] text-xs">Amount</p>
-                      <p className="font-semibold">{formatCurrency(payment.amount_due)}</p>
+                      <p className="font-semibold">{formatCurrency(payment.amount_due, payment.currency)}</p>
                     </div>
                     <div>
                       <p className="text-[var(--text-muted)] text-xs">Due Date</p>
@@ -483,7 +476,7 @@ export default function PaymentsPage() {
               <tbody>
                 {filteredPayments.map((payment, i) => {
                   const status = statusConfig[payment.status];
-                  const isPending = ["UPCOMING", "PENDING", "OVERDUE"].includes(payment.status);
+                  const isPending = ["upcoming", "pending", "overdue"].includes(payment.status);
 
                   return (
                     <tr
@@ -515,7 +508,7 @@ export default function PaymentsPage() {
                       </td>
                       <td>
                         <span className="font-semibold">
-                          {formatCurrency(payment.amount_due)}
+                          {formatCurrency(payment.amount_due, payment.currency)}
                         </span>
                       </td>
                       <td>
@@ -739,14 +732,6 @@ function MarkPaidModal({
     }
   };
 
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 0,
-    }).format(amount);
-  };
-
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal" onClick={(e) => e.stopPropagation()}>
@@ -783,7 +768,7 @@ function MarkPaidModal({
               <div className="flex items-center justify-between pt-3 border-t border-[var(--border)]">
                 <span className="text-[var(--text-secondary)]">Amount Due</span>
                 <span className="text-xl font-bold" style={{ fontFamily: "var(--font-outfit)" }}>
-                  {formatCurrency(payment.amount_due)}
+                  {formatCurrency(payment.amount_due, payment.currency)}
                 </span>
               </div>
             </div>
@@ -880,14 +865,6 @@ function WaiveModal({
     }
   };
 
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 0,
-    }).format(amount);
-  };
-
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal" onClick={(e) => e.stopPropagation()}>
@@ -915,7 +892,7 @@ function WaiveModal({
                   <p className="font-medium text-[var(--warning)]">This action cannot be undone</p>
                   <p className="text-sm text-[var(--text-secondary)] mt-1">
                     Waiving this payment will mark it as not required. The{" "}
-                    <strong>{formatCurrency(payment.amount_due)}</strong> will not be collected.
+                    <strong>{formatCurrency(payment.amount_due, payment.currency)}</strong> will not be collected.
                   </p>
                 </div>
               </div>
@@ -1130,14 +1107,6 @@ function RejectReceiptModal({
     }
   };
 
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 0,
-    }).format(amount);
-  };
-
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal" onClick={(e) => e.stopPropagation()}>
@@ -1165,7 +1134,7 @@ function RejectReceiptModal({
                   <p className="font-medium text-[var(--error)]">Reject uploaded receipt</p>
                   <p className="text-sm text-[var(--text-secondary)] mt-1">
                     The tenant will be notified that their receipt for{" "}
-                    <strong>{formatCurrency(payment.amount_due)}</strong> was rejected and will need
+                    <strong>{formatCurrency(payment.amount_due, payment.currency)}</strong> was rejected and will need
                     to upload a new one.
                   </p>
                 </div>

--- a/frontend/src/app/dashboard/properties/[id]/page.tsx
+++ b/frontend/src/app/dashboard/properties/[id]/page.tsx
@@ -329,7 +329,7 @@ export default function PropertyDetailPage() {
                     <div>
                       <h3 className="font-semibold">{room.name}</h3>
                       <p className="text-sm text-[var(--text-muted)]">
-                        {formatCurrency(room.rent_amount, room.currency)}/month
+                        {formatCurrency(room.rent_amount, room.currency)}/period
                       </p>
                     </div>
                   </div>
@@ -542,7 +542,7 @@ function RoomModal({
 
             <div>
               <label htmlFor="rent" className="label">
-                Monthly Rent
+                Rent Amount
               </label>
               <div className="flex gap-2">
                 {/* Currency Dropdown */}
@@ -1126,7 +1126,7 @@ function BulkRoomModal({
 
             {/* Currency and First Price */}
             <div>
-              <label className="label">Monthly Rent</label>
+              <label className="label">Rent Amount</label>
               <div className="flex gap-2">
                 {/* Currency Dropdown */}
                 <div className="relative">

--- a/frontend/src/app/dashboard/tenants/[id]/page.tsx
+++ b/frontend/src/app/dashboard/tenants/[id]/page.tsx
@@ -240,7 +240,7 @@ export default function TenantDetailPage() {
                     {tenant.room?.name}
                   </span>
                   <span className="text-sm font-medium">
-                    {formatCurrency(tenant.room?.rent_amount || 0, tenant.room?.currency)}/mo
+                    {formatCurrency(tenant.room?.rent_amount || 0, tenant.room?.currency)}/period
                   </span>
                 </div>
               </Link>

--- a/frontend/src/app/dashboard/tenants/[id]/page.tsx
+++ b/frontend/src/app/dashboard/tenants/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import api, { TenantWithDetails, Payment, PaymentStatus } from "@/lib/api";
+import { formatCurrency } from "@/lib/utils";
 import {
   ArrowLeft,
   Mail,
@@ -54,14 +55,6 @@ export default function TenantDetailPage() {
   useEffect(() => {
     void loadData();
   }, [loadData]);
-
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 0,
-    }).format(amount);
-  };
 
   const formatDate = (dateStr: string) => {
     return new Date(dateStr).toLocaleDateString("en-US", {
@@ -247,7 +240,7 @@ export default function TenantDetailPage() {
                     {tenant.room?.name}
                   </span>
                   <span className="text-sm font-medium">
-                    {formatCurrency(tenant.room?.rent_amount || 0)}/mo
+                    {formatCurrency(tenant.room?.rent_amount || 0, tenant.room?.currency)}/mo
                   </span>
                 </div>
               </Link>
@@ -274,7 +267,7 @@ export default function TenantDetailPage() {
                   <div className="flex justify-between text-sm">
                     <span className="text-[var(--text-muted)]">Amount</span>
                     <span className="font-medium">
-                      {formatCurrency(tenant.payment_schedule.amount)}
+                      {formatCurrency(tenant.payment_schedule.amount, tenant.room?.currency)}
                     </span>
                   </div>
                   <div className="flex justify-between text-sm">
@@ -312,7 +305,7 @@ export default function TenantDetailPage() {
             {[
               {
                 label: "Total Paid",
-                value: formatCurrency(totalPaid),
+                value: formatCurrency(totalPaid, tenant.room?.currency),
                 icon: DollarSign,
                 color: "success",
               },
@@ -386,7 +379,7 @@ export default function TenantDetailPage() {
               <div className="divide-y divide-[var(--border)]">
                 {tenant.payments.map((payment, i) => {
                   const status = statusConfig[payment.status];
-                  const isPending = ["UPCOMING", "PENDING", "OVERDUE"].includes(payment.status);
+                  const isPending = ["upcoming", "pending", "overdue"].includes(payment.status);
 
                   return (
                     <div
@@ -432,7 +425,7 @@ export default function TenantDetailPage() {
                         <div className="flex items-center gap-4">
                           <div className="text-right">
                             <p className="font-semibold">
-                              {formatCurrency(payment.amount_due)}
+                              {formatCurrency(payment.amount_due, tenant.room?.currency)}
                             </p>
                             <span className={`badge ${status.class}`}>
                               {status.label}
@@ -485,6 +478,7 @@ export default function TenantDetailPage() {
         <EditScheduleModal
           tenantId={tenant.id}
           schedule={tenant.payment_schedule}
+          currency={tenant.room?.currency}
           onClose={() => setShowEditSchedule(false)}
           onSave={() => {
             loadData();
@@ -522,6 +516,7 @@ export default function TenantDetailPage() {
         <MarkPaidModal
           payment={markPaidPayment}
           tenantName={tenant.name}
+          currency={tenant.room?.currency}
           onClose={() => setMarkPaidPayment(null)}
           onSave={() => {
             loadData();
@@ -548,7 +543,7 @@ function PaymentStatusBanner({
 }) {
   // Find next actionable payment (upcoming, pending, or overdue)
   const nextPayment = payments.find((p) =>
-    ["UPCOMING", "PENDING", "OVERDUE"].includes(p.status)
+    ["upcoming", "pending", "overdue"].includes(p.status)
   );
 
   if (!nextPayment) return null;
@@ -583,18 +578,6 @@ function PaymentStatusBanner({
     ? "Rent due today"
     : `Rent due in ${diffDays} day${diffDays !== 1 ? "s" : ""}`;
 
-  const formatBannerCurrency = (amount: number, currency?: string) => {
-    const curr = currency || "UGX";
-    if (["UGX", "KES", "TZS", "RWF"].includes(curr)) {
-      return `${curr} ${amount.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
-    }
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: curr,
-      minimumFractionDigits: 0,
-    }).format(amount);
-  };
-
   const formatBannerDate = (dateStr: string) => {
     return new Date(dateStr).toLocaleDateString("en-US", {
       month: "short",
@@ -620,7 +603,7 @@ function PaymentStatusBanner({
               {message}
             </p>
             <p className="text-sm text-[var(--text-secondary)]">
-              {formatBannerCurrency(nextPayment.amount_due, roomCurrency)} due{" "}
+              {formatCurrency(nextPayment.amount_due, roomCurrency)} due{" "}
               {formatBannerDate(nextPayment.due_date)}
             </p>
           </div>
@@ -744,22 +727,24 @@ function EditTenantModal({
 function EditScheduleModal({
   tenantId,
   schedule,
+  currency,
   onClose,
   onSave,
 }: {
   tenantId: string;
   schedule: TenantWithDetails["payment_schedule"];
+  currency?: string;
   onClose: () => void;
   onSave: () => void;
 }) {
   const [formData, setFormData] = useState<{
     amount: number;
-    frequency: "MONTHLY" | "BI_MONTHLY" | "QUARTERLY";
+    frequency: "monthly" | "bi_monthly" | "quarterly";
     due_day: number;
     window_days: number;
   }>({
     amount: schedule?.amount || 0,
-    frequency: schedule?.frequency || "MONTHLY",
+    frequency: schedule?.frequency || "monthly",
     due_day: schedule?.due_day || 1,
     window_days: schedule?.window_days || 5,
   });
@@ -805,8 +790,8 @@ function EditScheduleModal({
               <div>
                 <label className="label">Rent Amount</label>
                 <div className="relative">
-                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]">
-                    $
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)] font-medium text-sm">
+                    {currency || "UGX"}
                   </span>
                   <input
                     type="number"
@@ -814,7 +799,7 @@ function EditScheduleModal({
                     onChange={(e) =>
                       setFormData((prev) => ({ ...prev, amount: parseFloat(e.target.value) || 0 }))
                     }
-                    className="input pl-8"
+                    className="input !pl-16"
                     min="0"
                     required
                   />
@@ -824,12 +809,12 @@ function EditScheduleModal({
                 <label className="label">Frequency</label>
                 <select
                   value={formData.frequency}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, frequency: e.target.value as "MONTHLY" | "BI_MONTHLY" | "QUARTERLY" }))}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, frequency: e.target.value as "monthly" | "bi_monthly" | "quarterly" }))}
                   className="input"
                 >
-                  <option value="MONTHLY">Monthly</option>
-                  <option value="BI_MONTHLY">Bi-Monthly</option>
-                  <option value="QUARTERLY">Quarterly</option>
+                  <option value="monthly">Monthly</option>
+                  <option value="bi_monthly">Bi-Monthly</option>
+                  <option value="quarterly">Quarterly</option>
                 </select>
               </div>
             </div>
@@ -989,11 +974,13 @@ function MoveOutModal({
 function MarkPaidModal({
   payment,
   tenantName,
+  currency,
   onClose,
   onSave,
 }: {
   payment: Payment;
   tenantName: string;
+  currency?: string;
   onClose: () => void;
   onSave: () => void;
 }) {
@@ -1027,14 +1014,6 @@ function MarkPaidModal({
     }
   };
 
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 0,
-    }).format(amount);
-  };
-
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal" onClick={(e) => e.stopPropagation()}>
@@ -1059,7 +1038,7 @@ function MarkPaidModal({
               <div className="flex items-center justify-between">
                 <span className="text-[var(--text-secondary)]">{tenantName}</span>
                 <span className="text-xl font-bold" style={{ fontFamily: "var(--font-outfit)" }}>
-                  {formatCurrency(payment.amount_due)}
+                  {formatCurrency(payment.amount_due, currency)}
                 </span>
               </div>
             </div>

--- a/frontend/src/app/tenant/dashboard/ReceiptUploadModal.tsx
+++ b/frontend/src/app/tenant/dashboard/ReceiptUploadModal.tsx
@@ -1,15 +1,18 @@
 import { useState } from "react";
 import api, { Payment } from "@/lib/api";
+import { formatCurrency } from "@/lib/utils";
 import { Upload, X, CheckCircle, AlertCircle } from "lucide-react";
 
 interface ReceiptUploadModalProps {
   payment: Payment;
+  currency?: string;
   onClose: () => void;
   onSuccess: (payment: Payment) => void;
 }
 
 export default function ReceiptUploadModal({
   payment,
+  currency,
   onClose,
   onSuccess,
 }: ReceiptUploadModalProps) {
@@ -70,7 +73,7 @@ export default function ReceiptUploadModal({
                  <p className="text-sm text-[var(--primary-700)] font-medium mb-1">Payment Details</p>
                  <div className="flex justify-between items-center">
                     <span className="text-2xl font-bold text-[var(--primary-900)]">
-                        {new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(payment.amount_due)}
+                         {formatCurrency(payment.amount_due, currency)}
                     </span>
                     <span className="text-xs bg-white/50 px-2 py-1 rounded-md text-[var(--primary-800)]">
                         Due: {new Date(payment.due_date).toLocaleDateString()}

--- a/frontend/src/app/tenant/dashboard/page.tsx
+++ b/frontend/src/app/tenant/dashboard/page.tsx
@@ -252,7 +252,7 @@ export default function TenantDashboardPage() {
                  <Home className="w-6 h-6 text-[var(--primary-700)]" />
               </div>
               <div className="min-w-0">
-                 <p className="text-sm text-[var(--text-muted)]">Monthly Rent</p>
+                  <p className="text-sm text-[var(--text-muted)]">Rent Amount</p>
                  <p className="text-lg font-bold truncate">
                    {tenant.rent_amount ? formatCurrency(tenant.rent_amount) : tenant.room_name}
                  </p>

--- a/frontend/src/app/tenant/dashboard/page.tsx
+++ b/frontend/src/app/tenant/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import api, { Payment, TenantPortalResponse, PaymentStatus, PaymentDispute, LeaseAgreement } from "@/lib/api";
+import { formatCurrency } from "@/lib/utils";
 import ReceiptUploadModal from "./ReceiptUploadModal";
 import TenantMaintenanceSection from "./TenantMaintenanceSection";
 import {
@@ -378,7 +379,7 @@ export default function TenantDashboardPage() {
          <TenantMaintenanceSection />
 
          {/* Lease Agreement Section */}
-         <LeaseSection />
+         <LeaseSection currency={tenant?.room_currency} />
        </main>
  
        {/* Upload Modal */}
@@ -406,7 +407,7 @@ export default function TenantDashboardPage() {
   );
 }
 
-function LeaseSection() {
+function LeaseSection({ currency }: { currency?: string }) {
   const [lease, setLease] = useState<LeaseAgreement | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState("");
@@ -545,7 +546,7 @@ function LeaseSection() {
             <div>
               <p className="text-sm text-[var(--text-muted)]">Rent Amount</p>
               <p className="font-medium">
-                {formatCurrency(lease.rent_amount, tenant?.room_currency)}
+                {formatCurrency(lease.rent_amount, currency)}
               </p>
             </div>
           )}

--- a/frontend/src/app/tenant/dashboard/page.tsx
+++ b/frontend/src/app/tenant/dashboard/page.tsx
@@ -385,6 +385,7 @@ export default function TenantDashboardPage() {
       {uploadPayment && (
         <ReceiptUploadModal
           payment={uploadPayment}
+          currency={tenant?.room_currency}
           onClose={() => setUploadPayment(null)}
           onSuccess={(updatedPayment) => {
             setPayments(payments.map(p => p.id === updatedPayment.id ? updatedPayment : p));
@@ -544,11 +545,7 @@ function LeaseSection() {
             <div>
               <p className="text-sm text-[var(--text-muted)]">Rent Amount</p>
               <p className="font-medium">
-                {new Intl.NumberFormat("en-US", {
-                  style: "currency",
-                  currency: "USD",
-                  minimumFractionDigits: 0,
-                }).format(lease.rent_amount)}
+                {formatCurrency(lease.rent_amount, tenant?.room_currency)}
               </p>
             </div>
           )}

--- a/frontend/src/components/modals/AddTenantModal.tsx
+++ b/frontend/src/components/modals/AddTenantModal.tsx
@@ -34,6 +34,7 @@ export function AddTenantModal({
     window_days: 5,
     start_date: new Date().toISOString().split("T")[0],
   });
+  const [startDateManuallyEdited, setStartDateManuallyEdited] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
 
@@ -221,9 +222,13 @@ export function AddTenantModal({
                 <input
                   type="date"
                   value={formData.move_in_date}
-                  onChange={(e) =>
-                    setFormData((prev) => ({ ...prev, move_in_date: e.target.value }))
-                  }
+                  onChange={(e) => {
+                    const moveInDate = e.target.value;
+                    setFormData((prev) => ({ ...prev, move_in_date: moveInDate }));
+                    if (!startDateManuallyEdited) {
+                      setScheduleData((prev) => ({ ...prev, start_date: moveInDate }));
+                    }
+                  }}
                   className="input"
                   required
                 />
@@ -248,7 +253,7 @@ export function AddTenantModal({
                         }))
                       }
                       className="input !pl-16"
-                      min="0"
+                      min="1"
                       required
                     />
                   </div>
@@ -302,7 +307,7 @@ export function AddTenantModal({
                       }))
                     }
                     className="input"
-                    min="0"
+                    min="1"
                     max="15"
                   />
                   <p className="text-xs text-[var(--text-muted)] mt-1">
@@ -316,9 +321,10 @@ export function AddTenantModal({
                 <input
                   type="date"
                   value={scheduleData.start_date}
-                  onChange={(e) =>
-                    setScheduleData((prev) => ({ ...prev, start_date: e.target.value }))
-                  }
+                  onChange={(e) => {
+                    setScheduleData((prev) => ({ ...prev, start_date: e.target.value }));
+                    setStartDateManuallyEdited(true);
+                  }}
                   className="input"
                   required
                 />

--- a/frontend/src/components/modals/AddTenantModal.tsx
+++ b/frontend/src/components/modals/AddTenantModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useEffect } from "react";
 import api, { PropertyWithStats } from "@/lib/api";
+import { formatCurrency } from "@/lib/utils";
 import { X, ChevronRight } from "lucide-react";
 
 export function AddTenantModal({
@@ -165,7 +166,7 @@ export function AddTenantModal({
                       <option value="" disabled>Select a room</option>
                       {rooms.map((room) => (
                         <option key={room.id} value={room.id}>
-                          {room.name} — {room.currency} {room.rent_amount.toLocaleString()}/month
+                          {room.name} — {formatCurrency(room.rent_amount, room.currency)}/period
                         </option>
                       ))}
                     </select>

--- a/frontend/src/components/modals/AddTenantModal.tsx
+++ b/frontend/src/components/modals/AddTenantModal.tsx
@@ -29,7 +29,7 @@ export function AddTenantModal({
   });
   const [scheduleData, setScheduleData] = useState({
     amount: 0,
-    frequency: "BI_MONTHLY",
+    frequency: "bi_monthly",
     due_day: 1,
     window_days: 5,
     start_date: new Date().toISOString().split("T")[0],
@@ -262,9 +262,9 @@ export function AddTenantModal({
                     }
                     className="input"
                   >
-                    <option value="MONTHLY">Monthly</option>
-                    <option value="BI_MONTHLY">Bi-Monthly</option>
-                    <option value="QUARTERLY">Quarterly</option>
+                    <option value="monthly">Monthly</option>
+                    <option value="bi_monthly">Bi-Monthly</option>
+                    <option value="quarterly">Quarterly</option>
                   </select>
                 </div>
               </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -476,7 +476,7 @@ class ApiClient {
   async waivePayment(id: string, reason: string) {
     return this.request<Payment>(`/payments/${id}/waive`, {
       method: "PUT",
-      body: JSON.stringify({ reason }),
+      body: JSON.stringify({ notes: reason }),
     });
   }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -475,7 +475,7 @@ class ApiClient {
 
   async waivePayment(id: string, reason: string) {
     return this.request<Payment>(`/payments/${id}/waive`, {
-      method: "POST",
+      method: "PUT",
       body: JSON.stringify({ reason }),
     });
   }
@@ -1125,7 +1125,7 @@ export interface PaymentSchedule {
   id: string;
   tenant_id: string;
   amount: number;
-  frequency: "MONTHLY" | "BI_MONTHLY" | "QUARTERLY";
+  frequency: "monthly" | "bi_monthly" | "quarterly";
   due_day: number;
   window_days: number;
   start_date: string;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -906,16 +906,35 @@ class ApiClient {
     return this.request<void>(`/leases/${id}`, { method: "DELETE" });
   }
 
-  async downloadOriginalLease(leaseId: string) {
-    return this.request<Blob>(`/leases/${leaseId}/download-original`, {
+  private async downloadLeaseFile(endpoint: string): Promise<Blob> {
+    const token = this.getToken();
+    const headers: Record<string, string> = {};
+    if (token) {
+      headers["Authorization"] = `Bearer ${token}`;
+    }
+
+    const response = await fetch(`${API_BASE}${endpoint}`, {
       method: "GET",
+      headers,
+      credentials: "include",
     });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({
+        detail: "An error occurred during download",
+      }));
+      throw new Error(error.detail);
+    }
+
+    return response.blob();
   }
 
-  async downloadSignedLease(leaseId: string) {
-    return this.request<Blob>(`/leases/${leaseId}/download-signed`, {
-      method: "GET",
-    });
+  async downloadOriginalLease(leaseId: string): Promise<Blob> {
+    return this.downloadLeaseFile(`/leases/${leaseId}/download-original`);
+  }
+
+  async downloadSignedLease(leaseId: string): Promise<Blob> {
+    return this.downloadLeaseFile(`/leases/${leaseId}/download-signed`);
   }
 
   // Tenant Lease Endpoints

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared formatting helpers used across the frontend.
+ */
+
+const ZERO_DECIMAL_CURRENCIES = new Set(["UGX", "KES", "TZS", "RWF"]);
+
+/**
+ * Format an amount as a human-readable currency string.
+ *
+ * For common zero-decimal East African currencies the output is rendered as
+ * "CODE 1,234,567" (no fractional digits). All other currencies use the
+ * browser's Intl.NumberFormat with the supplied currency code.
+ */
+export function formatCurrency(amount: number, currency: string = "UGX"): string {
+  const safeAmount = Number.isFinite(amount) ? amount : 0;
+  const code = (currency || "UGX").toUpperCase();
+
+  if (ZERO_DECIMAL_CURRENCIES.has(code)) {
+    return `${code} ${safeAmount.toLocaleString("en-US", {
+      maximumFractionDigits: 0,
+      minimumFractionDigits: 0,
+    })}`;
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: code,
+    minimumFractionDigits: 0,
+  }).format(safeAmount);
+}


### PR DESCRIPTION
This PR consolidates the landlord demo-path fixes from #47, #48, and #49 into a single mergeable branch. It supersedes those PRs and resolves the branch-stacking issue where #49 did not include all of #48's billing-window fixes.

## Included from #47
- `TenantWithDetails` contract returns nested `room`, `property`, `payment_schedule`, and `payments`.
- First payment is generated after manual schedule creation.
- Payment summary totals are based on `amount_due`, not row counts.
- `GET /payments` supports `start_date` and `end_date` filters.
- Bulk room creation skips duplicate room names with warnings.
- Lowercase `PaymentFrequency` values across frontend/backend.
- `waivePayment` sends a `PUT` request.
- Shared `formatCurrency` helper with UGX-first formatting.

## Included from #48
- Inclusive payment window: `due_day=1` with `window_days=5` now ends on the 5th.
- `normalize_schedule_start()` prevents immediately-overdue payments for tenant creation and manual schedule creation.
- `grace_period_days` is persisted on property create/update.
- `VERIFYING` payments are not overwritten by the overdue refresh.
- Analytics refreshes payment statuses before aggregation.
- Public `/uploads` static mount removed; receipts only served via authenticated endpoint.
- "Monthly Rent" wording replaced with "Rent Amount" / per-period labels.

## Included from #49
- Backend default schedule frequency is `bi_monthly`.
- Waiver reason is sent as `notes` and persisted.
- `AddTenantModal` syncs move-in date with schedule start date unless manually edited.
- Schema validation for `amount > 0`, `due_day` 1–28, `window_days` 1–15.
- Payment summary verifies property ownership before filtering.
- `property_id` filtering added to `/payments/upcoming` and `/payments/overdue`.

## Additional fixes responding to Codex review on #48
- **Lease file access**: `frontend/src/app/dashboard/leases/page.tsx` now downloads original/signed copies through the authenticated `/leases/{id}/download-*` endpoints instead of the removed public `/uploads` static path.
- **No overlapping rent charges**: tenant creation now creates a prorated manual payment only when the normalized schedule is deferred to a later month. A mid-month move-in that still falls inside the payment window no longer produces both a full scheduled payment and a prorated payment for the same period.
- **Currency conversion in summary**: `/payments/summary` now converts each payment's room currency into the landlord's primary currency before summing expected/received/outstanding/overdue totals.
- **Update schedule validation**: `PaymentScheduleUpdate` now validates `amount > 0`, `due_day` 1–28, and `window_days` 1–15.

## Verification
- Backend: 672 tests pass (1 pre-existing config test fails due to local `MAIL_PASSWORD` env).
- Frontend: `npm run build` passes.

## Recommendation
Close #47, #48, and #49 unmerged, and merge this PR instead to avoid partial or conflicting state on `main`.
