### PR TITLE
fix(ui): tenant maintenance modal covered by lease section

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -566,17 +566,17 @@ a:hover { color: var(--primary-700); }
 
 @keyframes slideUp {
   from { opacity: 0; transform: translateY(16px); }
-  to { opacity: 1; transform: none; }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 @keyframes slideDown {
   from { opacity: 0; transform: translateY(-16px); }
-  to { opacity: 1; transform: none; }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 @keyframes scaleIn {
   from { opacity: 0; transform: scale(0.96); }
-  to { opacity: 1; transform: none; }
+  to { opacity: 1; transform: scale(1); }
 }
 
 @keyframes shimmer {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -566,17 +566,17 @@ a:hover { color: var(--primary-700); }
 
 @keyframes slideUp {
   from { opacity: 0; transform: translateY(16px); }
-  to { opacity: 1; transform: translateY(0); }
+  to { opacity: 1; transform: none; }
 }
 
 @keyframes slideDown {
   from { opacity: 0; transform: translateY(-16px); }
-  to { opacity: 1; transform: translateY(0); }
+  to { opacity: 1; transform: none; }
 }
 
 @keyframes scaleIn {
   from { opacity: 0; transform: scale(0.96); }
-  to { opacity: 1; transform: scale(1); }
+  to { opacity: 1; transform: none; }
 }
 
 @keyframes shimmer {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -566,17 +566,17 @@ a:hover { color: var(--primary-700); }
 
 @keyframes slideUp {
   from { opacity: 0; transform: translateY(16px); }
-  to { opacity: 1; transform: translateY(0); }
+  to { opacity: 1; transform: none; }
 }
 
 @keyframes slideDown {
   from { opacity: 0; transform: translateY(-16px); }
-  to { opacity: 1; transform: translateY(0); }
+  to { opacity: 1; transform: none; }
 }
 
 @keyframes scaleIn {
   from { opacity: 0; transform: scale(0.96); }
-  to { opacity: 1; transform: scale(1); }
+  to { opacity: 1; transform: none; }
 }
 
 @keyframes shimmer {
@@ -658,18 +658,22 @@ a:hover { color: var(--primary-700); }
   width: 100%;
   max-height: calc(100vh - 3rem);
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
   animation: scaleIn 0.25s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
 .modal-header {
   padding: 1.5rem 1.75rem;
   border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
 }
 
 .modal-body {
   padding: 1.75rem;
   overflow-y: auto;
-  max-height: calc(100vh - 14rem);
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .modal-footer {
@@ -679,6 +683,7 @@ a:hover { color: var(--primary-700); }
   justify-content: flex-end;
   gap: 0.75rem;
   background: var(--surface-inset);
+  flex-shrink: 0;
 }
 
 /* =========================================

--- a/frontend/src/app/tenant/dashboard/TenantMaintenanceSection.tsx
+++ b/frontend/src/app/tenant/dashboard/TenantMaintenanceSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import api, {
   MaintenanceCategory,
   MaintenanceRequest,
@@ -73,6 +74,9 @@ export default function TenantMaintenanceSection() {
   const [resolveOpen, setResolveOpen] = useState(false);
   const [resolveRating, setResolveRating] = useState("");
   const [resolveFeedback, setResolveFeedback] = useState("");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
 
   const [form, setForm] = useState({
     category: "other" as MaintenanceCategory,
@@ -337,7 +341,7 @@ export default function TenantMaintenanceSection() {
         )}
       </div>
 
-      {isCreateModalOpen && (
+      {mounted && isCreateModalOpen && createPortal(
         <div className="modal-overlay" onClick={closeCreateModal}>
           <div className="modal max-w-2xl" onClick={(event) => event.stopPropagation()}>
             <div className="modal-header flex items-center justify-between">
@@ -473,10 +477,11 @@ export default function TenantMaintenanceSection() {
               </button>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
 
-      {(selectedRequest || isDetailLoading) && (
+      {mounted && (selectedRequest || isDetailLoading) && createPortal(
         <div className="modal-overlay" onClick={() => setSelectedRequest(null)}>
           <div className="modal max-w-3xl" onClick={(event) => event.stopPropagation()}>
             <div className="modal-header flex items-center justify-between">
@@ -718,7 +723,8 @@ export default function TenantMaintenanceSection() {
               )}
             </div>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
     </section>
   );


### PR DESCRIPTION
## Problem

On the tenant dashboard, the **New Maintenance Request** modal was covered by the **Lease Agreement** section below it. The file upload field and Submit button were unreachable.

## Root cause

The \slideUp\, \slideDown\, and \scaleIn\ keyframes ended at \	ransform: translateY(0)\ / \scale(1)\ with \orwards\ fill mode. Any non-\
one\ transform permanently creates:

1. a **stacking context**, and
2. a **containing block** for \position: fixed\ descendants.

Both \TenantMaintenanceSection\ and \LeaseSection\ use \nimate-slide-up stagger-3\. The lease section comes after the maintenance section in the DOM, so per CSS paint order it rendered **on top** of the maintenance modal (whose z-index was trapped inside the maintenance section's stacking context). The modal's \ixed inset:0\ was also sized to the section box, not the viewport.

## Fix

\rontend/src/app/globals.css\:

1. End each entrance keyframe at \	ransform: none\ instead of \	ranslateY(0)\ / \scale(1)\. Visually identical, but \
one\ does **not** create a stacking context, so once the entrance animation finishes, fixed-position modals escape to the viewport and z-index resolves against the root.
2. Make \.modal\ a flex column with header/footer \lex-shrink: 0\ and body \lex: 1 1 auto; min-height: 0\ so tall modals (like the maintenance form) scroll internally while the Submit button stays pinned and visible. Replaces the fragile hardcoded \max-height: calc(100vh - 14rem)\ on \.modal-body\.

## Verification

- \
pm run build\ passes.
- Affects every modal in the app (receipt upload, dispute, lease upload, maintenance create/detail), not just the tenant side.

Closes the tenant-side issue where the lease card overlapped the maintenance request form.