### PR TITLE
fix(ui): notification dropdown clipped by header/sidebar

### DIFF
--- a/frontend/src/components/notification-bell.tsx
+++ b/frontend/src/components/notification-bell.tsx
@@ -107,9 +107,14 @@ export function NotificationBell() {
   const updatePosition = useCallback(() => {
     if (!buttonRef.current) return;
     const rect = buttonRef.current.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const dropdownWidth = Math.min(380, viewportWidth - 32); // 1rem padding each side
+    let right = viewportWidth - rect.right;
+    right = Math.max(16, right); // keep right edge at least 1rem from viewport
+    right = Math.min(right, viewportWidth - 16 - dropdownWidth); // keep left edge at least 1rem from viewport
     setDropdownStyle({
       top: rect.bottom + 8,
-      right: window.innerWidth - rect.right,
+      right,
     });
   }, []);
 

--- a/frontend/src/components/notification-bell.tsx
+++ b/frontend/src/components/notification-bell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { Bell, Check, CheckCheck, ChevronRight, Loader2 } from "lucide-react";
 import api, { NotificationItem } from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
@@ -60,8 +61,12 @@ export function NotificationBell() {
   const [notifications, setNotifications] = useState<NotificationItem[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const [dropdownStyle, setDropdownStyle] = useState({ top: 0, right: 0 });
   const dropdownRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => setMounted(true), []);
 
   const fetchNotifications = useCallback(async () => {
     if (!isAuthenticated) return;
@@ -98,6 +103,27 @@ export function NotificationBell() {
       console.error("Failed to mark all notifications as read:", error);
     }
   };
+
+  const updatePosition = useCallback(() => {
+    if (!buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    setDropdownStyle({
+      top: rect.bottom + 8,
+      right: window.innerWidth - rect.right,
+    });
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      updatePosition();
+    }
+  }, [isOpen, updatePosition]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    window.addEventListener("resize", updatePosition);
+    return () => window.removeEventListener("resize", updatePosition);
+  }, [isOpen, updatePosition]);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -159,11 +185,11 @@ export function NotificationBell() {
       </button>
 
       {/* Dropdown Panel */}
-      {isOpen && (
+      {mounted && isOpen && createPortal(
         <div
           ref={dropdownRef}
-          className="absolute right-0 top-full mt-2 w-[380px] bg-[var(--surface)] rounded-2xl shadow-[var(--shadow-xl)] border border-[var(--border)] overflow-hidden animate-slide-down"
-          style={{ animationDuration: "0.25s" }}
+          className="fixed z-[60] w-[min(380px,calc(100vw-2rem))] bg-[var(--surface)] rounded-2xl shadow-[var(--shadow-xl)] border border-[var(--border)] overflow-hidden animate-slide-down"
+          style={{ ...dropdownStyle, animationDuration: "0.25s" }}
         >
           {/* Header */}
           <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border)] bg-[var(--surface-inset)]">
@@ -278,7 +304,8 @@ export function NotificationBell() {
               Powered by SSE
             </span>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   );


### PR DESCRIPTION
## Problem

The notification bell dropdown was clipped depending on where the bell was rendered:

- In the **landlord sidebar** next to the LandTen logo, the 380px dropdown was wider than the 280px sidebar and overflowed.
- In the **mobile header**, a 380px fixed width could exceed narrow viewports.

## Fix

rontend/src/components/notification-bell.tsx:

1. **Portals the dropdown to document.body** so it escapes any parent clipping or stacking context (sidebar, header, transforms).
2. **Positions it with ixed** using viewport coordinates computed from the bell button's bounding rect (	op: button.bottom + 8, ight: viewport.width - button.right).
3. **Recomputes on resize** while the dropdown is open.
4. **Makes the width responsive** with w-[min(380px,calc(100vw-2rem))] so it never exceeds the viewport width.
5. Adds a mounted guard so the portal only renders client-side, avoiding SSR/hydration mismatches.

## Verification

- 
pm run build passes.
- Works for both landlord sidebar and mobile header placements because positioning is computed from the button's viewport rect.